### PR TITLE
Allow dynamic loading of TensorRT lib

### DIFF
--- a/trtx-sys/Cargo.toml
+++ b/trtx-sys/Cargo.toml
@@ -19,6 +19,9 @@ cc = "1.0"
 default = []
 # Mock mode for development without TensorRT-RTX installed
 mock = []
+onnxparser = []
+link_tensorrt_rtx = []
+link_tensorrt_onnxparser = ["onnxparser"]
 
 [dependencies]
 autocxx = "0.27"

--- a/trtx-sys/logger_bridge.cpp
+++ b/trtx-sys/logger_bridge.cpp
@@ -52,6 +52,7 @@
 
 #include "logger_bridge.hpp"
 #include <NvOnnxParser.h>
+#include <cstdint>
 #include <cstring>
 
 //==============================================================================
@@ -116,6 +117,7 @@ nvinfer1::ILogger* get_logger_interface(RustLoggerBridge* logger) {
 // Simpler to keep these thin wrappers than to work around autocxx limitations.
 
 // Factory functions for TensorRT
+#ifdef TRTX_LINK_TENSORRT_RTX
 void* create_infer_builder(void* logger) {
     if (!logger) {
         return nullptr;
@@ -139,7 +141,9 @@ void* create_infer_runtime(void* logger) {
         return nullptr;
     }
 }
+#endif
 
+#ifdef TRTX_LINK_TENSORRT_ONNXPARSER
 // ONNX Parser factory function
 void* create_onnx_parser(void* network, void* logger) {
     if (!network || !logger) {
@@ -153,6 +157,7 @@ void* create_onnx_parser(void* network, void* logger) {
         return nullptr;
     }
 }
+#endif
 
 //==============================================================================
 // SECTION 3: BUILDER & CONFIG METHODS (POTENTIALLY REDUNDANT)
@@ -419,6 +424,10 @@ void delete_parser(void* parser) {
     if (parser) {
         delete static_cast<nvonnxparser::IParser*>(parser);
     }
+}
+
+uint32_t get_tensorrt_version() {
+    return NV_TENSORRT_VERSION;
 }
 
 } // extern "C"

--- a/trtx-sys/src/lib.rs
+++ b/trtx-sys/src/lib.rs
@@ -135,6 +135,7 @@ pub mod real_bindings {
 
     // Logger bridge C functions
     extern "C" {
+        pub fn get_tensorrt_version() -> u32;
         pub fn create_rust_logger_bridge(
             callback: RustLogCallback,
             user_data: *mut std::ffi::c_void,
@@ -145,11 +146,14 @@ pub mod real_bindings {
         pub fn get_logger_interface(logger: *mut RustLoggerBridge) -> *mut std::ffi::c_void; // Returns ILogger*
 
         // TensorRT factory functions (wrapped as simple C functions)
+        #[cfg(feature = "link_tensorrt_rtx")]
         pub fn create_infer_builder(logger: *mut std::ffi::c_void) -> *mut std::ffi::c_void; // Returns IBuilder*
 
+        #[cfg(feature = "link_tensorrt_rtx")]
         pub fn create_infer_runtime(logger: *mut std::ffi::c_void) -> *mut std::ffi::c_void; // Returns IRuntime*
 
         // ONNX Parser factory function
+        #[cfg(feature = "link_tensorrt_onnxparser")]
         pub fn create_onnx_parser(
             network: *mut std::ffi::c_void,
             logger: *mut std::ffi::c_void,
@@ -323,6 +327,7 @@ pub mod real_bindings {
         pub use super::ffi::nvinfer1::*;
     }
 
+    #[cfg(feature = "onnxparser")]
     pub mod nvonnxparser {
         pub use super::ffi::nvonnxparser::*;
     }

--- a/trtx-sys/tests/method_call_test.rs
+++ b/trtx-sys/tests/method_call_test.rs
@@ -6,6 +6,7 @@
 #[cfg(not(feature = "mock"))]
 #[test]
 #[ignore] // Run with: cargo test --test method_call_test -- --ignored
+#[cfg(feature = "link_tensorrt_rtx")]
 fn test_builder_methods_callable() {
     use std::ptr;
 

--- a/trtx/Cargo.toml
+++ b/trtx/Cargo.toml
@@ -15,15 +15,34 @@ trtx-sys = { version = "0.2.0", path = "../trtx-sys", default-features = false }
 thiserror = "2.0"
 cxx = "1.0"
 libc = "0.2"
+libloading = { version = "0.9", optional = true }
 
 # cudarc for safe CUDA operations (required when real mode is enabled)
 # Using cuda-12050 as fallback; CUDA 13.x should be compatible
 cudarc = { version = "0.11", features = ["driver", "cuda-12050"], optional = true }
 
 [features]
-default = ["real"]   # real TensorRT-RTX with cudarc by default
+# real TensorRT-RTX with cudarc by and dynamic loading by default
+default = ["real", "dlopen_tensorrt_onnxparser", "dlopen_tensorrt_rtx", "onnxparser"]
 mock   = ["trtx-sys/mock"] # mock implementation (no CUDA required)
 real   = ["dep:cudarc"]    # real TensorRT-RTX (CUDA always required)
+link_tensorrt_rtx = ["trtx-sys/link_tensorrt_rtx"]
+dlopen_tensorrt_rtx = ["libloading"]
+link_tensorrt_onnxparser = ["trtx-sys/link_tensorrt_onnxparser", "onnxparser"]
+dlopen_tensorrt_onnxparser = ["libloading"]
+onnxparser = ["trtx-sys/onnxparser"]
 
 [dev-dependencies]
 # For examples and tests
+
+[[example]]
+name = "tiny_network"
+required-features = []
+
+[[example]]
+name = "basic_workflow"
+required-features = ["onnxparser"]
+
+[[example]]
+name = "rustnn_executor"
+required-features = ["onnxparser"]

--- a/trtx/examples/basic_workflow.rs
+++ b/trtx/examples/basic_workflow.rs
@@ -16,6 +16,11 @@ use trtx::builder::{network_flags, MemoryPoolType};
 use trtx::{Builder, Logger, Runtime};
 
 fn main() -> Result<(), Box<dyn Error>> {
+    #[cfg(feature = "dlopen_tensorrt_rtx")]
+    trtx::dynamically_load_tensorrt(None::<String>).unwrap();
+    #[cfg(feature = "dlopen_tensorrt_onnxparser")]
+    trtx::dynamically_load_tensorrt_onnxparser(None::<String>).unwrap();
+
     println!("TensorRT-RTX Basic Workflow Example");
     println!("=====================================\n");
 

--- a/trtx/examples/rustnn_executor.rs
+++ b/trtx/examples/rustnn_executor.rs
@@ -11,6 +11,9 @@ use std::error::Error;
 use trtx::executor::{run_onnx_with_tensorrt, run_onnx_zeroed, TensorInput};
 
 fn main() -> Result<(), Box<dyn Error>> {
+    #[cfg(feature = "dlopen_tensorrt_rtx")]
+    trtx::dynamically_load_tensorrt(None::<String>).unwrap();
+
     println!("TensorRT-RTX Executor for rustnn");
     println!("==================================\n");
 

--- a/trtx/examples/tiny_network.rs
+++ b/trtx/examples/tiny_network.rs
@@ -16,6 +16,11 @@ use trtx::network::Layer; // Import Layer trait for get_output method
 use trtx::{ActivationType, Builder, DataType, Logger, Runtime};
 
 fn main() -> Result<()> {
+    #[cfg(feature = "dlopen_tensorrt_rtx")]
+    trtx::dynamically_load_tensorrt(None::<String>).unwrap();
+    #[cfg(feature = "dlopen_tensorrt_onnxparser")]
+    trtx::dynamically_load_tensorrt_onnxparser(None::<String>).unwrap();
+
     println!("=== Tiny Network Example ===\n");
 
     // 1. Create logger

--- a/trtx/src/error.rs
+++ b/trtx/src/error.rs
@@ -40,6 +40,28 @@ pub enum Error {
     /// IO error
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+
+    #[error("TensorRT library not loaded")]
+    TrtRtxLibraryNotLoaded,
+
+    #[error("TensorRT onnxparser library not loaded")]
+    TrtOnnxParserLibraryNotLoaded,
+
+    #[cfg(any(
+        feature = "dlopen_tensorrt_rtx",
+        feature = "dlopen_tensorrt_onnxparser"
+    ))]
+    #[error("Dynamic loading error: {0}")]
+    Libloading(#[from] libloading::Error),
+
+    #[error("Would unwrap a poisened lock")]
+    LockPoisining,
+}
+
+impl<T> From<std::sync::PoisonError<T>> for Error {
+    fn from(_: std::sync::PoisonError<T>) -> Self {
+        Error::LockPoisining
+    }
 }
 
 impl Error {

--- a/trtx/src/executor.rs
+++ b/trtx/src/executor.rs
@@ -3,10 +3,13 @@
 //! This module provides a simplified API for executing ONNX models with TensorRT,
 //! designed to integrate easily with rustnn's executor pattern.
 
+#[cfg(feature = "onnxparser")]
 use crate::builder::network_flags;
 use crate::cuda::DeviceBuffer;
 use crate::error::Result;
-use crate::{Builder, Logger, OnnxParser, Runtime};
+#[cfg(feature = "onnxparser")]
+use crate::{Builder, OnnxParser};
+use crate::{Logger, Runtime};
 
 /// Input descriptor for TensorRT execution
 #[derive(Debug, Clone)]
@@ -40,6 +43,7 @@ pub struct TensorOutput {
 /// # Returns
 ///
 /// Vector of output tensors with names, shapes, and computed data
+#[cfg(feature = "onnxparser")]
 pub fn run_onnx_with_tensorrt(
     onnx_model_bytes: &[u8],
     inputs: &[TensorInput],
@@ -55,6 +59,7 @@ pub fn run_onnx_with_tensorrt(
 }
 
 /// Build TensorRT engine from ONNX model
+#[cfg(feature = "onnxparser")]
 fn build_engine_from_onnx(logger: &Logger, onnx_bytes: &[u8]) -> Result<Vec<u8>> {
     // Create builder
     let builder = Builder::new(logger)?;
@@ -194,6 +199,7 @@ fn execute_engine(
 }
 
 /// Simpler version: Execute with zero-filled inputs (useful for testing/validation)
+#[cfg(feature = "onnxparser")]
 pub fn run_onnx_zeroed(
     onnx_model_bytes: &[u8],
     input_descriptors: &[(String, Vec<usize>)],
@@ -233,6 +239,7 @@ mod tests {
 
     #[test]
     #[ignore] // Requires valid ONNX model
+    #[cfg(feature = "onnxparser")]
     fn test_executor_basic() {
         let dummy_onnx = vec![0u8; 100];
         let inputs = vec![("input".to_string(), vec![1, 3, 224, 224])];

--- a/trtx/tests/dynloading.rs
+++ b/trtx/tests/dynloading.rs
@@ -1,0 +1,39 @@
+#[cfg(test)]
+#[cfg(not(feature = "mock"))]
+#[cfg(feature = "dlopen_tensorrt_rtx")]
+#[cfg(feature = "dlopen_tensorrt_onnxparser")]
+mod tests {
+    use trtx::{Builder, Logger, OnnxParser};
+
+    // this needs to be in a single test in a separate test file to be isolated into a  dedicated
+    // test binary
+    #[test]
+    fn dynloading() {
+        let logger = Logger::stderr().unwrap();
+
+        // not linking let's builder creation fail
+        #[cfg(not(feature = "link_tensorrt_rtx"))]
+        assert!(matches!(
+            Builder::new(&logger),
+            Err(trtx::Error::TrtRtxLibraryNotLoaded)
+        ));
+
+        // Loading the library fixes the error
+        trtx::dynamically_load_tensorrt(None::<String>).unwrap();
+
+        let logger = Logger::stderr().unwrap();
+        let builder = Builder::new(&logger).unwrap();
+        let mut network = builder.create_network(0).unwrap();
+
+        // not linking let's builder creation fail
+        #[cfg(not(feature = "link_tensorrt_onnxparser"))]
+        assert!(matches!(
+            OnnxParser::new(&mut network, &logger),
+            Err(trtx::Error::TrtOnnxParserLibraryNotLoaded)
+        ));
+
+        // Loading the library fixes the error
+        trtx::dynamically_load_tensorrt_onnxparser(None::<String>).unwrap();
+        OnnxParser::new(&mut network, &logger).unwrap();
+    }
+}


### PR DESCRIPTION
This is a draft of allowing dynamic loading of the TensorRT libs. Actual diff here https://github.com/rustnn/trtx-rs/pull/3/changes/cefe2c14465bffc535ff940ee911c529d057402c

It is on top of the refactoring of #2 . I would wait whether #2 will be adopted or not and rebase accordingly. I would also wait with this PR on how this projects decides to select TensorRT versions (either via TensorRT present in dev enviornment or by checking in TensorRT headers)

The premise of this change is that both linking of the TensorRT lib and the ONNX parser link and dynamic loading should be Cargo features to which a user of the crate can opt-in or opt-out (no strong opinion what the default features of the crates should be).

Making dynload the default would enable vendoring the TRT headers and not require the TensorRT libs to be present in the dev environment. One could even vendor the headers of different TensorRT version and select the concrete version via Cargo feature or by analyzing the  TensorRT library to be dynamically loaded.

Also the ONNX parser should be a Cargo feature. This way users that don't use ONNX don't need to generate unnecessary code.

