### PR TITLE
feat: add handler for logging with `log` crate

### DIFF
--- a/trtx/Cargo.toml
+++ b/trtx/Cargo.toml
@@ -21,6 +21,7 @@ autocxx = { version = "0.30" }
 # cudarc for safe CUDA operations (required when real mode is enabled)
 # Using cuda-12050 as fallback; CUDA 13.x should be compatible
 cudarc = { version = "0.11", features = ["driver", "cuda-12050"] }
+log = "0.4.29"
 
 [features]
 # real TensorRT-RTX with cudarc by and dynamic loading by default
@@ -44,6 +45,7 @@ v_1_4 = ["trtx-sys/v_1_4"]
 
 [dev-dependencies]
 # For examples and tests
+pretty_env_logger = "0.5"
 
 [[example]]
 name = "tiny_network"

--- a/trtx/examples/basic_workflow.rs
+++ b/trtx/examples/basic_workflow.rs
@@ -16,6 +16,9 @@ use trtx::builder::{network_flags, MemoryPoolType};
 use trtx::{Builder, Logger, Runtime};
 
 fn main() -> Result<(), Box<dyn Error>> {
+    // Initialize logging use pretty_env_logger crate
+    pretty_env_logger::init();
+
     #[cfg(feature = "dlopen_tensorrt_rtx")]
     trtx::dynamically_load_tensorrt(None::<String>).unwrap();
     #[cfg(feature = "dlopen_tensorrt_onnxparser")]
@@ -26,7 +29,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Step 1: Create logger
     println!("1. Creating logger...");
-    let logger = Logger::stderr()?;
+    let logger = Logger::log_crate()?;
     println!("   ✓ Logger created\n");
 
     // Step 2: Build phase

--- a/trtx/src/logger.rs
+++ b/trtx/src/logger.rs
@@ -32,6 +32,20 @@ impl LogHandler for StderrLogger {
     }
 }
 
+pub struct LogCrateLogger;
+
+impl LogHandler for LogCrateLogger {
+    fn log(&self, severity: Severity, message: &str) {
+        match severity {
+            Severity::InternalError => log::error!(target: "trtx::tensorrt", "{message}"),
+            Severity::Error => log::error!(target: "trtx::tensorrt", "{message}"),
+            Severity::Warning => log::warn!(target: "trtx::tensorrt", "{message}"),
+            Severity::Info => log::info!(target: "trtx::tensorrt", "{message}"),
+            Severity::Verbose => log::debug!(target: "trtx::tensorrt", "{message}"),
+        }
+    }
+}
+
 /// Logger (uses Rust bridge to TensorRT)
 pub struct Logger {
     bridge: *mut trtx_sys::RustLoggerBridge,
@@ -60,6 +74,10 @@ impl Logger {
 
     pub fn stderr() -> crate::Result<Self> {
         Self::new(StderrLogger)
+    }
+
+    pub fn log_crate() -> crate::Result<Self> {
+        Self::new(LogCrateLogger)
     }
 
     pub(crate) fn as_logger_ptr(&self) -> *mut std::ffi::c_void {


### PR DESCRIPTION
I would assume that this is what people would expect from a Rust crate. The `log` crate does by default nothing, but if enabled it can be customized until infinity by users. With `RUST_LOG`, you can filter by category and crate and in your crate settings you can compile-time set min/max log levels.

We could add the `log` crate just behind a feature but I would advertise to just use it in more locations in our crate. Most Rust crates use `log` already and a library with logging is just easier to debug.

Before (stderr logger):

<img width="1270" height="379" alt="image" src="https://github.com/user-attachments/assets/0853e010-ba9d-40cd-9474-44d26bead09b" />

After (when user decides to log with pretty_env_logger):

(two runs: with and without RUST_LOG set)

<img width="1270" height="810" alt="image" src="https://github.com/user-attachments/assets/3e3c202b-c6e7-40cb-88c8-a9647b473e80" />

We could even remove the concept of the Logger in the high-level crate all together given how much the `log` crate is used in the Rust ecosystem. An advantage for the stderr logger is however that it does not need to be enabled by the user via a third-level crate that customizes logging.

And yeah, the basic example is currently failing in `real` mode (not mock) due to the network not having any marked input/outputs. But this is kind of expected given the  comments in the example and the example output