### PR TITLE
feat: dynamically load TRT libraries on demand

### DIFF
--- a/trtx/src/real/builder.rs
+++ b/trtx/src/real/builder.rs
@@ -72,6 +72,9 @@ impl<'a> Builder<'a> {
                 use std::ffi::c_void;
 
                 use crate::TRTLIB;
+                if !TRTLIB.read()?.is_some() {
+                    crate::dynamically_load_tensorrt(None::<String>)?;
+                }
 
                 let lock = TRTLIB.read()?;
                 let create_infer_builder: Symbol<fn(*mut c_void, u32) -> *mut c_void> = lock

--- a/trtx/src/real/onnx_parser.rs
+++ b/trtx/src/real/onnx_parser.rs
@@ -38,6 +38,10 @@ impl OnnxParser {
 
                 use crate::TRT_ONNXPARSER_LIB;
 
+                if !TRT_ONNXPARSER_LIB.read()?.is_some() {
+                    crate::dynamically_load_tensorrt_onnxparser(None::<String>)?;
+                }
+
                 let lock = TRT_ONNXPARSER_LIB
                     .read()
                     .map_err(|_| Error::LockPoisining)?;

--- a/trtx/src/real/runtime.rs
+++ b/trtx/src/real/runtime.rs
@@ -188,6 +188,9 @@ impl<'a> Runtime<'a> {
                 use std::ffi::c_void;
 
                 use crate::TRTLIB;
+                if !TRTLIB.read()?.is_some() {
+                    crate::dynamically_load_tensorrt(None::<String>)?;
+                }
 
                 let lock = TRTLIB.read()?;
                 let create_infer_builder: Symbol<fn(*mut c_void, u32) -> *mut c_void> = lock


### PR DESCRIPTION
Previously, we required an explicit call to dynamically load the libraries. We might do that for the user if they decided to not need a specific load path for the libraries.

Should we do that automatically?