### PR TITLE
build: transform TensorRT-Headers if necessary

### DIFF
--- a/trtx-sys/Cargo.toml
+++ b/trtx-sys/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["external-ffi-bindings"]
 [build-dependencies]
 autocxx-build = "0.30"
 cc = "1.0"
+regex = "1.0"
 
 [features]
 default = ["v_1_3"]

--- a/trtx-sys/TensorRT-Headers/TRT-RTX-1.3/NvInfer.h
+++ b/trtx-sys/TensorRT-Headers/TRT-RTX-1.3/NvInfer.h
@@ -10066,7 +10066,7 @@ public:
     //!
     //! \deprecated Deprecated in TensorRT-RTX 1.2. Timing cache operations are no-ops in TensorRT-RTX.
     //!
-    TRT_DEPRECATED nvinfer1::ITimingCache* createTimingCache(void const* blob, size_t size) const noexcept
+    TRT_DEPRECATED nvinfer1::ITimingCache* createTimingCache(void const* blob, std::size_t size) const noexcept
     {
         return mImpl->createTimingCache(blob, size);
     }
@@ -10135,7 +10135,7 @@ public:
     //!
     //! \see getMemoryPoolLimit, MemoryPoolType
     //!
-    void setMemoryPoolLimit(MemoryPoolType pool, size_t poolSize) noexcept
+    void setMemoryPoolLimit(MemoryPoolType pool, std::size_t poolSize) noexcept
     {
         mImpl->setMemoryPoolLimit(pool, poolSize);
     }
@@ -10154,7 +10154,7 @@ public:
     //!
     //! \see setMemoryPoolLimit
     //!
-    size_t getMemoryPoolLimit(MemoryPoolType pool) const noexcept
+    std::size_t getMemoryPoolLimit(MemoryPoolType pool) const noexcept
     {
         return mImpl->getMemoryPoolLimit(pool);
     }

--- a/trtx-sys/TensorRT-Headers/TRT-RTX-1.3/NvInferImpl.h
+++ b/trtx-sys/TensorRT-Headers/TRT-RTX-1.3/NvInferImpl.h
@@ -241,7 +241,7 @@ class VHostMemory : public VRoot
 {
 public:
     virtual void* data() const noexcept = 0;
-    virtual size_t size() const noexcept = 0;
+    virtual std::size_t size() const noexcept = 0;
     virtual DataType type() const noexcept = 0;
 };
 
@@ -269,7 +269,7 @@ class VRuntime : public VRoot
 {
 public:
     virtual IRuntime* getPImpl() noexcept = 0;
-    virtual nvinfer1::ICudaEngine* deserializeCudaEngine(void const* blob, size_t size) noexcept = 0;
+    virtual nvinfer1::ICudaEngine* deserializeCudaEngine(void const* blob, std::size_t size) noexcept = 0;
     virtual nvinfer1::ICudaEngine* deserializeCudaEngine(IStreamReader& streamReader) noexcept = 0;
     virtual void setDLACore(int32_t dlaCore) noexcept = 0;
     virtual int32_t getDLACore() const noexcept = 0;
@@ -1275,11 +1275,11 @@ public:
     virtual ProfilingVerbosity getProfilingVerbosity() const noexcept = 0;
     virtual bool setTacticSources(TacticSources tacticSources) noexcept = 0;
     virtual TacticSources getTacticSources() const noexcept = 0;
-    virtual nvinfer1::ITimingCache* createTimingCache(void const* blob, size_t size) const noexcept = 0;
+    virtual nvinfer1::ITimingCache* createTimingCache(void const* blob, std::size_t size) const noexcept = 0;
     virtual bool setTimingCache(ITimingCache const& cache, bool ignoreMismatch) noexcept = 0;
     virtual nvinfer1::ITimingCache const* getTimingCache() const noexcept = 0;
-    virtual void setMemoryPoolLimit(MemoryPoolType pool, size_t poolSize) noexcept = 0;
-    virtual size_t getMemoryPoolLimit(MemoryPoolType pool) const noexcept = 0;
+    virtual void setMemoryPoolLimit(MemoryPoolType pool, std::size_t poolSize) noexcept = 0;
+    virtual std::size_t getMemoryPoolLimit(MemoryPoolType pool) const noexcept = 0;
     virtual void setPreviewFeature(PreviewFeature feature, bool enable) noexcept = 0;
     virtual bool getPreviewFeature(PreviewFeature feature) const noexcept = 0;
     virtual void setBuilderOptimizationLevel(int32_t level) noexcept = 0;

--- a/trtx-sys/TensorRT-Headers/TRT-RTX-1.3/NvInferRuntime.h
+++ b/trtx-sys/TensorRT-Headers/TRT-RTX-1.3/NvInferRuntime.h
@@ -150,7 +150,7 @@ public:
     }
 
     //! The size in bytes of the data that was allocated.
-    size_t size() const noexcept
+    std::size_t size() const noexcept
     {
         return mImpl->size();
     }
@@ -2019,7 +2019,7 @@ public:
     //!
     //! \return The engine, or nullptr if it could not be deserialized.
     //!
-    ICudaEngine* deserializeCudaEngine(void const* blob, size_t size) noexcept
+    ICudaEngine* deserializeCudaEngine(void const* blob, std::size_t size) noexcept
     {
         return mImpl->deserializeCudaEngine(blob, size);
     }

--- a/trtx-sys/build.rs
+++ b/trtx-sys/build.rs
@@ -1,10 +1,55 @@
 use std::env;
-use std::path::PathBuf;
+use std::fs::File;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use regex::Regex;
+
+/// Creates a folder in `out_dir`, copies headers from `trt_dir` with transformations applied,
+/// and returns the path to the new folder. Original headers are never modified.
+fn prepare_transformed_headers(trt_dir: &Path, out_dir: &Path) -> PathBuf {
+    let doxy_regex = Regex::new(r"\\(\w+)").unwrap();
+    let warn_regex = Regex::new(r"\\warning (.*)$").unwrap();
+    let see_regex = Regex::new(r"\\see ([`\w:()]+)").unwrap();
+    let param_regex = Regex::new(r"\\param ([\w:()]+)").unwrap();
+    let comment_indent_regex = Regex::new(r"(///\ )(\ +)").unwrap();
+
+    let transformed_dir = out_dir.join("trtx_transformed_headers");
+    std::fs::create_dir_all(&transformed_dir).expect("Failed to create transformed headers dir");
+
+    for entry in std::fs::read_dir(trt_dir).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if path.is_file() {
+            let replaced = std::fs::read_to_string(&path).unwrap();
+            let replaced = warn_regex.replace_all(&replaced, "<div class=\"warning\"> $1 </div>");
+            let replaced = see_regex.replace_all(&replaced, "See [`$1`]");
+            let replaced = param_regex.replace_all(&replaced, "- `$1`");
+            let replaced = replaced
+                .replace("std::size_t", "size_t")
+                .replace("//!", "///")
+                .replace(r"\returns", " - Returns ");
+            let replaced = doxy_regex.replace_all(&replaced, "");
+            // trimming of indentation is necessary, so that rustdoc doesn't interpret
+            // indented sections as Rust code.
+            let replaced = comment_indent_regex
+                .replace_all(&replaced, "$1")
+                .replace("\r\n", "\n");
+
+            let out_file = transformed_dir.join(path.file_name().unwrap());
+            let mut file = File::create(&out_file).unwrap();
+            let _ = file.write(replaced.as_bytes()).unwrap();
+        }
+    }
+
+    transformed_dir
+}
 
 fn main() {
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     let link_trt = env::var("CARGO_FEATURE_LINK_TENSORRT_RTX").is_ok();
     let link_trt_onnxparser = env::var("CARGO_FEATURE_LINK_TENSORRT_ONNXPARSER").is_ok();
+
     println!("cargo:rerun-if-env-changed=CARGO_FEATURE_LINK_TENSORRT_RTX");
     println!("cargo:rerun-if-env-changed=CARGO_FEATURE_LINK_TENSORRT_ONNXPARSER");
 
@@ -45,9 +90,15 @@ fn main() {
     #[cfg(feature = "v_1_3")]
     let trt_version = "1.3";
 
-    let include_dir = format!("{crate_root}/TensorRT-Headers/TRT-RTX-{trt_version}");
+    let include_dir = PathBuf::from(format!(
+        "{crate_root}/TensorRT-Headers/TRT-RTX-{trt_version}"
+    ));
+    println!("cargo:rerun-if-changed={}", include_dir.display());
     let cuda_shim_include_dir = format!("{crate_root}/TensorRT-Headers");
     let lib_dir = format!("{trtx_dir}/lib");
+
+    let transformed_include_dir = prepare_transformed_headers(&include_dir, &out_path);
+    let transformed_include_dir_str = transformed_include_dir.to_string_lossy();
 
     #[cfg(unix)]
     let trt_version_suffix = "";
@@ -68,7 +119,7 @@ fn main() {
     cc_build
         .cpp(true)
         .file("logger_bridge.cpp")
-        .include(&include_dir)
+        .include(&transformed_include_dir)
         .include(&cuda_shim_include_dir);
 
     if link_trt {
@@ -99,11 +150,16 @@ fn main() {
         "-Wno-deprecated-declarations", // Suppress deprecated warnings from TensorRT headers
     ];
 
-    let mut autocxx_build =
-        autocxx_build::Builder::new("src/lib.rs", [&include_dir, &cuda_shim_include_dir])
-            .extra_clang_args(&clang_args)
-            .build()
-            .expect("Failed to build autocxx bindings");
+    let mut autocxx_build = autocxx_build::Builder::new(
+        "src/lib.rs",
+        [
+            transformed_include_dir_str.as_ref(),
+            cuda_shim_include_dir.as_str(),
+        ],
+    )
+    .extra_clang_args(&clang_args)
+    .build()
+    .expect("Failed to build autocxx bindings");
 
     // Set C++17 standard and suppress warnings
     if cfg!(target_os = "windows") && cfg!(target_env = "msvc") {


### PR DESCRIPTION
For better autocxx we transformed `std::size_t` -> `size_t` manually.

Let's do this in our build step so we don't forget this for future TensorRT-Headers.

While we are at it, we can also do some simple replacements to transform TensorRT's doxygen documentation into something that is better parseable by rustdoc.

Especically, replacing `//!` `///` and removing all doxygen commands `\\(\w*)` yields substantially better results for objects in the trtx-sys crate. We might reference the now usable documentation in the high-level `trtx` crate.