### PR TITLE
fix(onnxparser)!: Make sure the parser can't be dropped before build

### DIFF
--- a/trtexec-rs/src/main.rs
+++ b/trtexec-rs/src/main.rs
@@ -201,9 +201,9 @@ fn main() -> Result<()> {
 
         let mut _graph = None;
         let mut network = builder.create_network(0)?;
-        let mut parser = OnnxParser::new(&mut network, &logger)?;
+        let mut _parser = None;
         let file_extension = onnx_path.extension();
-        if file_extension == Some(&OsString::from("json"))
+        let network = if file_extension == Some(&OsString::from("json"))
             || file_extension == Some(&OsString::from("webnn"))
         {
             info!("Processing as RustNN file: {onnx_path:?}");
@@ -217,26 +217,31 @@ fn main() -> Result<()> {
                 _graph.as_ref().unwrap(),
                 &mut network,
             )?;
+            &mut network
         } else {
             debug!("Processing as ONNX file: {onnx_path:?}");
-
+            let mut parser = OnnxParser::new(network, &logger)?;
             parser.parse_from_file(&onnx_path.to_string_lossy().clone(), 5)?;
-        }
+
+            // keep parser alive
+            _parser = Some(parser);
+            _parser.as_mut().unwrap().network_mut()
+        };
 
         let mut shape_changed = false;
         for i in 0..network.get_nb_inputs() {
             let mut input = network.get_input(i)?;
-            let shape = input.dimensions(&network)?;
-            let name = input.name(&network)?;
+            let shape = input.dimensions(network)?;
+            let name = input.name(network)?;
             let resolved = resolve_dynamic_input_shape(args.non_interactive, &name, &shape)?;
             if resolved != shape {
                 shape_changed = true;
-                input.set_dimensions(&mut network, &resolved);
+                input.set_dimensions(network, &resolved);
             }
         }
 
         let serialized = builder
-            .build_serialized_network(&mut network, &mut config)
+            .build_serialized_network(network, &mut config)
             .with_context(|| format!("Fail to build {onnx_path:?}"))?;
 
         if !shape_changed {

--- a/trtx/src/executor.rs
+++ b/trtx/src/executor.rs
@@ -64,11 +64,12 @@ fn build_engine_from_onnx(logger: &Logger, onnx_bytes: &[u8]) -> Result<Vec<u8>>
     let mut builder = Builder::new(logger)?;
 
     // Create network with explicit batch
-    let mut network = builder.create_network(network_flags::EXPLICIT_BATCH)?;
+    let network = builder.create_network(network_flags::EXPLICIT_BATCH)?;
 
     // Parse ONNX model
-    let mut parser = OnnxParser::new(&mut network, logger)?;
+    let mut parser = OnnxParser::new(network, logger)?;
     parser.parse(onnx_bytes)?;
+    let network = parser.network_mut();
 
     // Configure builder
     let mut config = builder.create_config()?;
@@ -77,7 +78,7 @@ fn build_engine_from_onnx(logger: &Logger, onnx_bytes: &[u8]) -> Result<Vec<u8>>
     config.set_memory_pool_limit(MemoryPoolType::kWORKSPACE, 1 << 30);
 
     // Build serialized engine
-    let memory = builder.build_serialized_network(&mut network, &mut config)?;
+    let memory = builder.build_serialized_network(network, &mut config)?;
 
     // This makes an extra copy since the `memory` depends on the lifetime of builder
     Ok(memory.to_vec())

--- a/trtx/src/onnx_parser.rs
+++ b/trtx/src/onnx_parser.rs
@@ -2,12 +2,11 @@
 //!
 //! [`OnnxParser`] wraps [`trtx_sys::nvonnxparser::IParser`] (C++ [`nvonnxparser::IParser`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvonnxparser_1_1_i_parser.html)).
 
-use std::marker::PhantomData;
 use std::path::PathBuf;
 
 use cxx::UniquePtr;
 use std::ffi::{c_void, CString};
-use trtx_sys::{nvinfer1, nvonnxparser};
+use trtx_sys::nvonnxparser;
 
 use crate::error::{Error, Result};
 use crate::logger::Logger;
@@ -16,10 +15,10 @@ use crate::network::NetworkDefinition;
 /// [`trtx_sys::nvonnxparser::IParser`] — C++ [`nvonnxparser::IParser`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvonnxparser_1_1_i_parser.html).
 pub struct OnnxParser<'network> {
     inner: UniquePtr<nvonnxparser::IParser>,
-    _network: PhantomData<&'network nvinfer1::INetworkDefinition>,
+    network: NetworkDefinition<'network>,
 }
 
-impl OnnxParser<'_> {
+impl<'parser> OnnxParser<'parser> {
     #[cfg(not(any(
         feature = "link_tensorrt_onnxparser",
         feature = "dlopen_tensorrt_onnxparser"
@@ -32,7 +31,11 @@ impl OnnxParser<'_> {
         feature = "link_tensorrt_onnxparser",
         feature = "dlopen_tensorrt_onnxparser"
     ))]
-    pub fn new(network: &mut NetworkDefinition, logger: &Logger) -> Result<Self> {
+    /// Creates a new Parser. This consumes NetworkDefinition to ensure the parser is not dropped
+    /// before the network build is finished (as the parser holds the weights).
+    ///
+    /// Use [OnnxParser::network], [OnnxParser::network_mut] to get a borrow to the network
+    pub fn new(network: NetworkDefinition<'parser>, logger: &Logger) -> Result<Self> {
         #[cfg(not(feature = "mock"))]
         {
             let network_ptr = network.inner.as_mut_ptr();
@@ -75,13 +78,13 @@ impl OnnxParser<'_> {
             }
             Ok(OnnxParser {
                 inner: unsafe { UniquePtr::from_raw(parser_ptr) },
-                _network: Default::default(),
+                network,
             })
         }
         #[cfg(feature = "mock")]
         Ok(OnnxParser {
             inner: UniquePtr::null(),
-            _network: Default::default(),
+            network,
         })
     }
 
@@ -141,22 +144,27 @@ impl OnnxParser<'_> {
         }
         Ok(())
     }
+
+    pub fn network(&'parser self) -> &'parser NetworkDefinition<'parser> {
+        &self.network
+    }
+
+    pub fn network_mut(&'parser mut self) -> &'parser mut NetworkDefinition<'parser> {
+        &mut self.network
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::builder::network_flags;
     use crate::{Builder, Logger};
 
     #[test]
     fn test_onnx_parser_creation() {
         let logger = Logger::stderr().unwrap();
         let mut builder = Builder::new(&logger).unwrap();
-        let mut network = builder
-            .create_network(network_flags::EXPLICIT_BATCH)
-            .unwrap();
-        let parser = OnnxParser::new(&mut network, &logger);
+        let network = builder.create_network(0).unwrap();
+        let parser = OnnxParser::new(network, &logger);
         assert!(parser.is_ok());
     }
 
@@ -170,10 +178,8 @@ mod tests {
         let model_bytes = std::fs::read(model_path).expect("Failed to read test ONNX model");
         let logger = Logger::stderr().unwrap();
         let mut builder = Builder::new(&logger).unwrap();
-        let mut network = builder
-            .create_network(network_flags::EXPLICIT_BATCH)
-            .unwrap();
-        let mut parser = OnnxParser::new(&mut network, &logger).unwrap();
+        let network = builder.create_network(0).unwrap();
+        let mut parser = OnnxParser::new(network, &logger).unwrap();
         let result = parser.parse(&model_bytes);
         assert!(
             result.is_ok(),

--- a/trtx/tests/dynloading.rs
+++ b/trtx/tests/dynloading.rs
@@ -14,10 +14,10 @@ mod tests {
 
         let logger = Logger::stderr().unwrap();
         let mut builder = Builder::new(&logger).unwrap();
-        let mut network = builder.create_network(0).unwrap();
+        let network = builder.create_network(0).unwrap();
 
         // Loading the library fixes the error
         trtx::dynamically_load_tensorrt_onnxparser(None::<String>).unwrap();
-        OnnxParser::new(&mut network, &logger).unwrap();
+        OnnxParser::new(network, &logger).unwrap();
     }
 }


### PR DESCRIPTION
Before one could do

```rs
    let mut network = builder.create_network(0)?;
    if do_parse {
	  debug!("Processing as ONNX file: {onnx_path:?}");
	  let mut parser = OnnxParser::new(&mut network, &logger)?;
	  parser.parse_from_file(&onnx_path.to_string_lossy().clone(), 5)?;
	  // parser dropped here
    }

    // build uses weights from dropped parser
    let serialized = builder
	  .build_serialized_network(&mut network, &mut config)
	  .with_context(|| format!("Fail to build {onnx_path:?}"))?;

    // parser creation needs to be hoisted from if to have it still alive
    // during build
```

uses #70 (where I saw this mistake)

Suggestion is to do
```rs
  let mut network = builder.create_network(0)?;
  let mut parser = OnnxParser::new(network, &logger)?;
  // network consumed by parser. Can't use network anymore without living parser

  // access to network only via getter, ensures living parser
  let serialized = builder
    .build_serialized_network(parser.network_mut(), &mut config)
    .with_context(|| format!("Fail to build {onnx_path:?}"))?;
```

Fixes https://github.com/rustnn/trtx-rs/issues/71