### PR TITLE
feat: add `ExecutionContext::set_communicator`

### DIFF
--- a/trtx/src/error.rs
+++ b/trtx/src/error.rs
@@ -20,6 +20,7 @@ pub enum PropertySetAttempt {
     BuilderConfigNbComputeCapabilities,
     BuilderConfigComputeCapability,
     ExecutionContextTensorDebugState,
+    ExecutionContextNcclCommunicator,
     DequantizeLayerBlockShape,
     QuantizeLayerBlockShape,
     AttentionLayerInput,

--- a/trtx/src/execution_context.rs
+++ b/trtx/src/execution_context.rs
@@ -206,4 +206,20 @@ impl<'a> ExecutionContext<'a> {
         }
         Ok(())
     }
+
+    #[cfg(feature = "v_1_4")]
+    /// See [nvinfer1::IExecutionContext::setCommunicator]
+    ///
+    /// # Safety
+    /// `comm` must be a pointer to a valid NCCL communicator and follow valid NCCL/CUDA
+    /// usage
+    pub unsafe fn set_communicator(&mut self, comm: *mut std::ffi::c_void) -> Result<()> {
+        if self.inner.pin_mut().setCommunicator(comm as *mut _) {
+            Ok(())
+        } else {
+            Err(Error::FailedToSetProperty(
+                crate::error::PropertySetAttempt::ExecutionContextNcclCommunicator,
+            ))
+        }
+    }
 }


### PR DESCRIPTION
Allows to set NCCL communicator for multi-device engines.