### PR TITLE
refactor!: remove `get_` prefix from getters

### DIFF
--- a/trtexec-rs/src/main.rs
+++ b/trtexec-rs/src/main.rs
@@ -224,8 +224,8 @@ fn main() -> Result<()> {
         }
 
         let mut shape_changed = false;
-        for i in 0..network.get_nb_inputs() {
-            let mut input = network.get_input(i)?;
+        for i in 0..network.nb_inputs() {
+            let mut input = network.input(i)?;
             let shape = input.dimensions(&network)?;
             let name = input.name(&network)?;
             let resolved = resolve_dynamic_input_shape(args.non_interactive, &name, &shape)?;
@@ -282,8 +282,7 @@ fn main() -> Result<()> {
         }
 
         let inspector = engine.create_engine_inspector()?;
-        let engine_layer_info_json =
-            inspector.get_engine_information(LayerInformationFormat::kJSON)?;
+        let engine_layer_info_json = inspector.engine_information(LayerInformationFormat::kJSON)?;
         let layer_json_path = args.engine_dir.join(format!(
             "{}.graph.json",
             input_path

--- a/trtx/examples/tiny_network.rs
+++ b/trtx/examples/tiny_network.rs
@@ -89,7 +89,7 @@ fn main() -> Result<()> {
 
     // 8. Execute inference
     println!("8. Running inference...");
-    let stream = trtx::cuda::get_default_stream();
+    let stream = trtx::cuda::default_stream();
     unsafe {
         context.enqueue_v3(stream)?;
     }
@@ -178,7 +178,7 @@ fn build_tiny_network(logger: &Logger) -> Result<Vec<u8>> {
 
     println!("   Adding ReLU activation layer...");
     let activation_layer = network.add_activation(&input, ActivationType::kRELU)?;
-    let output = activation_layer.get_output(&network, 0)?;
+    let output = activation_layer.output(&network, 0)?;
 
     println!("   Setting output tensor name...");
     let output_named = output;
@@ -188,8 +188,8 @@ fn build_tiny_network(logger: &Logger) -> Result<Vec<u8>> {
     println!("   Marking output tensor...");
     network.mark_output(&output_named);
 
-    println!("   Network has {} inputs", network.get_nb_inputs());
-    println!("   Network has {} outputs", network.get_nb_outputs());
+    println!("   Network has {} inputs", network.nb_inputs());
+    println!("   Network has {} outputs", network.nb_outputs());
 
     println!("   Creating builder config...");
     let mut config = builder.create_config()?;

--- a/trtx/src/builder_config.rs
+++ b/trtx/src/builder_config.rs
@@ -78,12 +78,17 @@ impl BuilderConfig {
     }
 
     /// See [IBuilderConfig::getProfilingVerbosity]
-    pub fn get_profiling_verbosity(&self) -> ProfilingVerbosity {
+    pub fn profiling_verbosity(&self) -> ProfilingVerbosity {
         if cfg!(not(feature = "mock")) {
             self.inner.getProfilingVerbosity().into()
         } else {
             ProfilingVerbosity::kNONE
         }
+    }
+
+    #[deprecated = "use profiling_verbosity instead"]
+    pub fn get_profiling_verbosity(&self) -> ProfilingVerbosity {
+        self.profiling_verbosity()
     }
 
     /// See [IBuilderConfig::setAvgTimingIterations]
@@ -93,12 +98,17 @@ impl BuilderConfig {
     }
 
     /// See [IBuilderConfig::getAvgTimingIterations]
-    pub fn get_avg_timing_iterations(&self) -> i32 {
+    pub fn avg_timing_iterations(&self) -> i32 {
         if cfg!(not(feature = "mock")) {
             self.inner.getAvgTimingIterations()
         } else {
             0
         }
+    }
+
+    #[deprecated = "use avg_timing_iterations instead"]
+    pub fn get_avg_timing_iterations(&self) -> i32 {
+        self.avg_timing_iterations()
     }
 
     /// See [IBuilderConfig::setEngineCapability]
@@ -108,12 +118,17 @@ impl BuilderConfig {
     }
 
     /// See [IBuilderConfig::getEngineCapability]
-    pub fn get_engine_capability(&self) -> EngineCapability {
+    pub fn engine_capability(&self) -> EngineCapability {
         if cfg!(not(feature = "mock")) {
             self.inner.getEngineCapability().into()
         } else {
             EngineCapability::kSTANDARD
         }
+    }
+
+    #[deprecated = "use engine_capability instead"]
+    pub fn get_engine_capability(&self) -> EngineCapability {
+        self.engine_capability()
     }
 
     /// See [IBuilderConfig::setFlags]
@@ -123,12 +138,17 @@ impl BuilderConfig {
     }
 
     /// See [IBuilderConfig::getFlags]
-    pub fn get_flags(&self) -> u32 {
+    pub fn flags(&self) -> u32 {
         if cfg!(not(feature = "mock")) {
             self.inner.getFlags()
         } else {
             0
         }
+    }
+
+    #[deprecated = "use flags instead"]
+    pub fn get_flags(&self) -> u32 {
+        self.flags()
     }
 
     /// See [IBuilderConfig::setFlag]
@@ -144,12 +164,17 @@ impl BuilderConfig {
     }
 
     /// See [IBuilderConfig::getFlag]
-    pub fn get_flag(&self, flag: BuilderFlag) -> bool {
+    pub fn flag(&self, flag: BuilderFlag) -> bool {
         if cfg!(not(feature = "mock")) {
             self.inner.getFlag(flag.into())
         } else {
             false
         }
+    }
+
+    #[deprecated = "use flag instead"]
+    pub fn get_flag(&self, flag: BuilderFlag) -> bool {
+        self.flag(flag)
     }
 
     /// See [IBuilderConfig::setDLACore]
@@ -159,12 +184,17 @@ impl BuilderConfig {
     }
 
     /// See [IBuilderConfig::getDLACore]
-    pub fn get_dla_core(&self) -> i32 {
+    pub fn dla_core(&self) -> i32 {
         if cfg!(not(feature = "mock")) {
             self.inner.getDLACore()
         } else {
             0
         }
+    }
+
+    #[deprecated = "use dla_core instead"]
+    pub fn get_dla_core(&self) -> i32 {
+        self.dla_core()
     }
 
     /// See [IBuilderConfig::setDefaultDeviceType]
@@ -176,12 +206,17 @@ impl BuilderConfig {
     }
 
     /// See [IBuilderConfig::getDefaultDeviceType]
-    pub fn get_default_device_type(&self) -> DeviceType {
+    pub fn default_device_type(&self) -> DeviceType {
         if cfg!(not(feature = "mock")) {
             self.inner.getDefaultDeviceType().into()
         } else {
             DeviceType::kGPU
         }
+    }
+
+    #[deprecated = "use default_device_type instead"]
+    pub fn get_default_device_type(&self) -> DeviceType {
+        self.default_device_type()
     }
 
     /// See [IBuilderConfig::reset]
@@ -191,12 +226,17 @@ impl BuilderConfig {
     }
 
     /// See [IBuilderConfig::getNbOptimizationProfiles]
-    pub fn get_nb_optimization_profiles(&self) -> i32 {
+    pub fn nb_optimization_profiles(&self) -> i32 {
         if cfg!(not(feature = "mock")) {
             self.inner.getNbOptimizationProfiles()
         } else {
             0
         }
+    }
+
+    #[deprecated = "use nb_optimization_profiles instead"]
+    pub fn get_nb_optimization_profiles(&self) -> i32 {
+        self.nb_optimization_profiles()
     }
 
     /// See [IBuilderConfig::addOptimizationProfile].
@@ -238,7 +278,7 @@ impl BuilderConfig {
     }
 
     /// See [IBuilderConfig::getTacticSources]
-    pub fn get_tactic_sources(&self) -> u32 {
+    pub fn tactic_sources(&self) -> u32 {
         if cfg!(not(feature = "mock")) {
             self.inner.getTacticSources()
         } else {
@@ -246,13 +286,23 @@ impl BuilderConfig {
         }
     }
 
+    #[deprecated = "use tactic_sources instead"]
+    pub fn get_tactic_sources(&self) -> u32 {
+        self.tactic_sources()
+    }
+
     /// See [IBuilderConfig::getMemoryPoolLimit]
-    pub fn get_memory_pool_limit(&self, pool: MemoryPoolType) -> usize {
+    pub fn memory_pool_limit(&self, pool: MemoryPoolType) -> usize {
         if cfg!(not(feature = "mock")) {
             self.inner.getMemoryPoolLimit(pool.into())
         } else {
             0
         }
+    }
+
+    #[deprecated = "use memory_pool_limit instead"]
+    pub fn get_memory_pool_limit(&self, pool: MemoryPoolType) -> usize {
+        self.memory_pool_limit(pool)
     }
 
     /// See [IBuilderConfig::setPreviewFeature]
@@ -264,12 +314,17 @@ impl BuilderConfig {
     }
 
     /// See [IBuilderConfig::getPreviewFeature]
-    pub fn get_preview_feature(&self, feature: PreviewFeature) -> bool {
+    pub fn preview_feature(&self, feature: PreviewFeature) -> bool {
         if cfg!(not(feature = "mock")) {
             self.inner.getPreviewFeature(feature.into())
         } else {
             false
         }
+    }
+
+    #[deprecated = "use preview_feature instead"]
+    pub fn get_preview_feature(&self, feature: PreviewFeature) -> bool {
+        self.preview_feature(feature)
     }
 
     /// See [IBuilderConfig::setBuilderOptimizationLevel]
@@ -279,12 +334,17 @@ impl BuilderConfig {
     }
 
     /// See [IBuilderConfig::getBuilderOptimizationLevel]
-    pub fn get_builder_optimization_level(&mut self) -> i32 {
+    pub fn builder_optimization_level(&mut self) -> i32 {
         if cfg!(not(feature = "mock")) {
             self.inner.pin_mut().getBuilderOptimizationLevel()
         } else {
             0
         }
+    }
+
+    #[deprecated = "use builder_optimization_level instead"]
+    pub fn get_builder_optimization_level(&mut self) -> i32 {
+        self.builder_optimization_level()
     }
 
     /// See [IBuilderConfig::setHardwareCompatibilityLevel]
@@ -296,8 +356,13 @@ impl BuilderConfig {
     }
 
     /// See [IBuilderConfig::getHardwareCompatibilityLevel]
-    pub fn get_hardware_compatibility_level(&self) -> HardwareCompatibilityLevel {
+    pub fn hardware_compatibility_level(&self) -> HardwareCompatibilityLevel {
         self.inner.getHardwareCompatibilityLevel().into()
+    }
+
+    #[deprecated = "use hardware_compatibility_level instead"]
+    pub fn get_hardware_compatibility_level(&self) -> HardwareCompatibilityLevel {
+        self.hardware_compatibility_level()
     }
 
     /// See [IBuilderConfig::setMaxAuxStreams]
@@ -307,12 +372,17 @@ impl BuilderConfig {
     }
 
     /// See [IBuilderConfig::getMaxAuxStreams]
-    pub fn get_max_aux_streams(&self) -> i32 {
+    pub fn max_aux_streams(&self) -> i32 {
         if cfg!(not(feature = "mock")) {
             self.inner.getMaxAuxStreams()
         } else {
             0
         }
+    }
+
+    #[deprecated = "use max_aux_streams instead"]
+    pub fn get_max_aux_streams(&self) -> i32 {
+        self.max_aux_streams()
     }
 
     /// See [IBuilderConfig::setRuntimePlatform]
@@ -322,12 +392,17 @@ impl BuilderConfig {
     }
 
     /// See [IBuilderConfig::getRuntimePlatform]
-    pub fn get_runtime_platform(&self) -> RuntimePlatform {
+    pub fn runtime_platform(&self) -> RuntimePlatform {
         if cfg!(not(feature = "mock")) {
             self.inner.getRuntimePlatform().into()
         } else {
             RuntimePlatform::kSAME_AS_BUILD
         }
+    }
+
+    #[deprecated = "use runtime_platform instead"]
+    pub fn get_runtime_platform(&self) -> RuntimePlatform {
+        self.runtime_platform()
     }
 
     /// See [IBuilderConfig::setMaxNbTactics]
@@ -337,12 +412,17 @@ impl BuilderConfig {
     }
 
     /// See [IBuilderConfig::getMaxNbTactics]
-    pub fn get_max_nb_tactics(&self) -> i32 {
+    pub fn max_nb_tactics(&self) -> i32 {
         if cfg!(not(feature = "mock")) {
             self.inner.getMaxNbTactics()
         } else {
             0
         }
+    }
+
+    #[deprecated = "use max_nb_tactics instead"]
+    pub fn get_max_nb_tactics(&self) -> i32 {
+        self.max_nb_tactics()
     }
 
     /// See [IBuilderConfig::setTilingOptimizationLevel]
@@ -368,12 +448,17 @@ impl BuilderConfig {
     }
 
     /// See [IBuilderConfig::getTilingOptimizationLevel]
-    pub fn get_tiling_optimization_level(&self) -> TilingOptimizationLevel {
+    pub fn tiling_optimization_level(&self) -> TilingOptimizationLevel {
         if cfg!(not(feature = "mock")) {
             self.inner.getTilingOptimizationLevel().into()
         } else {
             TilingOptimizationLevel::kNONE
         }
+    }
+
+    #[deprecated = "use tiling_optimization_level instead"]
+    pub fn get_tiling_optimization_level(&self) -> TilingOptimizationLevel {
+        self.tiling_optimization_level()
     }
 
     /// See [IBuilderConfig::setL2LimitForTiling]
@@ -392,12 +477,17 @@ impl BuilderConfig {
     }
 
     /// See [IBuilderConfig::getL2LimitForTiling]
-    pub fn get_l2_limit_for_tiling(&self) -> i64 {
+    pub fn l2_limit_for_tiling(&self) -> i64 {
         if cfg!(not(feature = "mock")) {
             self.inner.getL2LimitForTiling()
         } else {
             0
         }
+    }
+
+    #[deprecated = "use l2_limit_for_tiling instead"]
+    pub fn get_l2_limit_for_tiling(&self) -> i64 {
+        self.l2_limit_for_tiling()
     }
 
     /// See [IBuilderConfig::setNbComputeCapabilities]
@@ -425,7 +515,7 @@ impl BuilderConfig {
 
     /// See [IBuilderConfig::getNbComputeCapabilities]
     #[cfg(not(feature = "enterprise"))]
-    pub fn get_nb_compute_capabilities(&self) -> i32 {
+    pub fn nb_compute_capabilities(&self) -> i32 {
         if cfg!(not(feature = "mock")) {
             self.inner.getNbComputeCapabilities()
         } else {
@@ -434,8 +524,13 @@ impl BuilderConfig {
     }
 
     #[cfg(not(feature = "enterprise"))]
-    /// See [IBuilderConfig::setComputeCapability]
+    #[deprecated = "use nb_compute_capabilities instead"]
+    pub fn get_nb_compute_capabilities(&self) -> i32 {
+        self.nb_compute_capabilities()
+    }
+
     #[cfg(not(feature = "enterprise"))]
+    /// See [IBuilderConfig::setComputeCapability]
     pub fn set_compute_capability(
         &mut self,
         compute_capability: ComputeCapability,
@@ -460,13 +555,18 @@ impl BuilderConfig {
 
     #[cfg(not(feature = "enterprise"))]
     /// See [IBuilderConfig::getComputeCapability]
-    #[cfg(not(feature = "enterprise"))]
-    pub fn get_compute_capability(&self, index: i32) -> ComputeCapability {
+    pub fn compute_capability(&self, index: i32) -> ComputeCapability {
         if cfg!(not(feature = "mock")) {
             self.inner.getComputeCapability(index).into()
         } else {
             ComputeCapability::kNONE
         }
+    }
+
+    #[cfg(not(feature = "enterprise"))]
+    #[deprecated = "use compute_capability instead"]
+    pub fn get_compute_capability(&self, index: i32) -> ComputeCapability {
+        self.compute_capability(index)
     }
 }
 
@@ -532,7 +632,7 @@ mod tests {
         for i in 0..NUM_LAYERS {
             let mut layer = network.add_identity(&tensor)?;
             layer.set_name(&mut network, &format!("layer_{}", i))?;
-            tensor = layer.get_output(&network, 0)?;
+            tensor = layer.output(&network, 0)?;
         }
         tensor.set_name(&mut network, "output")?;
         network.mark_output(&tensor);

--- a/trtx/src/cuda.rs
+++ b/trtx/src/cuda.rs
@@ -64,8 +64,13 @@ pub fn synchronize() -> Result<()> {
 }
 
 /// Get the default CUDA stream
-pub fn get_default_stream() -> *mut std::ffi::c_void {
+pub fn default_stream() -> *mut std::ffi::c_void {
     std::ptr::null_mut()
+}
+
+#[deprecated = "use default_stream instead"]
+pub fn get_default_stream() -> *mut std::ffi::c_void {
+    default_stream()
 }
 
 #[cfg(test)]

--- a/trtx/src/cuda_engine.rs
+++ b/trtx/src/cuda_engine.rs
@@ -76,29 +76,30 @@ impl<'engine> CudaEngine<'engine> {
         }
     }
 
+    #[deprecated = "use nb_io_tensors instead"]
+    pub fn get_nb_io_tensors(&self) -> Result<i32> {
+        self.nb_io_tensors()
+    }
+    #[deprecated = "use tensor_shape instead"]
+    pub fn get_tensor_shape(&self, name: &str) -> Result<Vec<i64>> {
+        self.tensor_shape(name)
+    }
+    #[deprecated = "use io_tensor_name instead"]
+    pub fn get_tensor_name(&self, index: i32) -> Result<String> {
+        self.io_tensor_name(index)
+    }
+    #[deprecated = "use tensor_data_type instead"]
+    pub fn get_tensor_dtype(&self, name: &str) -> Result<DataType> {
+        self.tensor_data_type(name)
+    }
+
+    /// See [ICudaEngine::getName]
     pub fn name(&self) -> Result<String> {
         let ptr = self.inner.getName();
         if ptr.is_null() {
             return Ok(String::new());
         }
         Ok(unsafe { CStr::from_ptr(ptr) }.to_str()?.to_string())
-    }
-
-    #[deprecated = "use nb_io_tensors"]
-    pub fn get_nb_io_tensors(&self) -> Result<i32> {
-        self.nb_io_tensors()
-    }
-    #[deprecated = "use tensor_shape"]
-    pub fn get_tensor_shape(&self, name: &str) -> Result<Vec<i64>> {
-        self.tensor_shape(name)
-    }
-    #[deprecated = "use io_tensor_name"]
-    pub fn get_tensor_name(&self, index: i32) -> Result<String> {
-        self.io_tensor_name(index)
-    }
-    #[deprecated = "use tensor_data_type"]
-    pub fn get_tensor_dtype(&self, name: &str) -> Result<DataType> {
-        self.tensor_data_type(name)
     }
 
     /// See [`nvinfer1::ICudaEngine::getNbIOTensors`].
@@ -316,7 +317,7 @@ impl<'engine> CudaEngine<'engine> {
         }
     }
 
-    #[deprecated = "use tensor_data_type"]
+    #[deprecated = "use tensor_data_type instead"]
     pub fn tensor_dtype(&self, name: &str) -> Result<DataType> {
         self.tensor_data_type(name)
     }
@@ -397,12 +398,12 @@ mod tests {
         tensor = network
             .add_activation(&tensor, ActivationType::kRELU)
             .unwrap()
-            .get_output(&network, 0)
+            .output(&network, 0)
             .unwrap();
         tensor = network
             .add_activation(&tensor, ActivationType::kRELU)
             .unwrap()
-            .get_output(&network, 0)
+            .output(&network, 0)
             .unwrap();
         network.mark_output(&tensor);
 
@@ -427,7 +428,7 @@ mod tests {
 
         let inspector = engine.create_engine_inspector().expect("engine inspector");
         let json = inspector
-            .get_engine_information(LayerInformationFormat::kJSON)
+            .engine_information(LayerInformationFormat::kJSON)
             .expect("get_engine_information JSON");
 
         assert!(

--- a/trtx/src/engine_inspector.rs
+++ b/trtx/src/engine_inspector.rs
@@ -17,7 +17,7 @@ pub struct EngineInspector<'engine> {
 impl EngineInspector<'_> {
     /// Returns layer information for the given layer index in the requested format.
     /// See [`trtx_sys::nvinfer1::IEngineInspector::getLayerInformation`].
-    pub fn get_layer_information(
+    pub fn layer_information(
         &mut self,
         layer_index: i32,
         format: LayerInformationFormat,
@@ -32,9 +32,18 @@ impl EngineInspector<'_> {
         })
     }
 
+    #[deprecated = "use layer_information instead"]
+    pub fn get_layer_information(
+        &mut self,
+        layer_index: i32,
+        format: LayerInformationFormat,
+    ) -> Result<String> {
+        self.layer_information(layer_index, format)
+    }
+
     /// Returns engine information in the requested format.
     /// See [`trtx_sys::nvinfer1::IEngineInspector::getEngineInformation`].
-    pub fn get_engine_information(&self, format: LayerInformationFormat) -> Result<String> {
+    pub fn engine_information(&self, format: LayerInformationFormat) -> Result<String> {
         let ptr = self.inner.getEngineInformation(format.into());
         Ok(if ptr.is_null() {
             return Err(Error::Runtime(
@@ -43,5 +52,10 @@ impl EngineInspector<'_> {
         } else {
             unsafe { CStr::from_ptr(ptr) }.to_str()?.to_string()
         })
+    }
+
+    #[deprecated = "use engine_information instead"]
+    pub fn get_engine_information(&self, format: LayerInformationFormat) -> Result<String> {
+        self.engine_information(format)
     }
 }

--- a/trtx/src/executor.rs
+++ b/trtx/src/executor.rs
@@ -168,7 +168,7 @@ fn execute_engine(
 
     // Execute inference
     unsafe {
-        context.enqueue_v3(crate::cuda::get_default_stream())?;
+        context.enqueue_v3(crate::cuda::default_stream())?;
     }
 
     // Synchronize to ensure completion

--- a/trtx/src/lib.rs
+++ b/trtx/src/lib.rs
@@ -68,9 +68,9 @@
 //! let context = engine.create_execution_context()?;
 //!
 //! // List I/O tensors
-//! let num_tensors = engine.get_nb_io_tensors()?;
+//! let num_tensors = engine.nb_io_tensors()?;
 //! for i in 0..num_tensors {
-//!     let name = engine.get_tensor_name(i)?;
+//!     let name = engine.io_tensor_name(i)?;
 //!     println!("Tensor {}: {}", i, name);
 //! }
 //! # Ok(())
@@ -146,7 +146,7 @@ pub mod tensor;
 // Re-export commonly used types
 pub use axes::Axes;
 pub use builder::{Builder, BuilderConfig, ProfilingVerbosity};
-pub use cuda::{get_default_stream, synchronize, DeviceBuffer};
+pub use cuda::{default_stream, synchronize, DeviceBuffer};
 pub use error::{Error, Result};
 #[cfg(feature = "onnxparser")]
 pub use executor::{run_onnx_with_tensorrt, run_onnx_zeroed};

--- a/trtx/src/network.rs
+++ b/trtx/src/network.rs
@@ -136,36 +136,56 @@ impl<'network, Inner: AsLayer> Layer<'network, Inner> {
     }
 
     /// See [nvinfer1::ILayer::getInput]
-    pub fn get_input(
-        &self,
-        network: &'_ NetworkDefinition,
-        index: i32,
-    ) -> Result<Tensor<'network>> {
+    pub fn input(&self, network: &'_ NetworkDefinition, index: i32) -> Result<Tensor<'network>> {
         check_network!(network, self);
         let tensor = self.inner.as_layer().getInput(index);
         unsafe { Tensor::new(self.network, tensor) }
     }
 
+    #[deprecated = "use input instead"]
+    pub fn get_input(
+        &self,
+        network: &'_ NetworkDefinition,
+        index: i32,
+    ) -> Result<Tensor<'network>> {
+        self.input(network, index)
+    }
+
     /// See [nvinfer1::ILayer::getOutput]
+    pub fn output(&self, network: &'_ NetworkDefinition, index: i32) -> Result<Tensor<'network>> {
+        check_network!(network, self);
+        let tensor = self.inner.as_layer().getOutput(index);
+        unsafe { Tensor::new(self.network, tensor) }
+    }
+
+    #[deprecated = "use output instead"]
     pub fn get_output(
         &self,
         network: &'_ NetworkDefinition,
         index: i32,
     ) -> Result<Tensor<'network>> {
-        check_network!(network, self);
-        let tensor = self.inner.as_layer().getOutput(index);
-        unsafe { Tensor::new(self.network, tensor) }
+        self.output(network, index)
     }
     /// See [nvinfer1::ILayer::getNbInputs]
-    pub fn get_num_inputs(&self, network: &'_ NetworkDefinition) -> i32 {
+    pub fn num_inputs(&self, network: &'_ NetworkDefinition) -> i32 {
         check_network!(network, self);
         self.inner.as_layer().getNbInputs()
     }
 
+    #[deprecated = "use num_inputs instead"]
+    pub fn get_num_inputs(&self, network: &'_ NetworkDefinition) -> i32 {
+        self.num_inputs(network)
+    }
+
     /// See [nvinfer1::ILayer::getNbOutputs]
-    pub fn get_num_outputs(&self, network: &'_ NetworkDefinition) -> i32 {
+    pub fn num_outputs(&self, network: &'_ NetworkDefinition) -> i32 {
         check_network!(network, self);
         self.inner.as_layer().getNbOutputs()
+    }
+
+    #[deprecated = "use num_outputs instead"]
+    pub fn get_num_outputs(&self, network: &'_ NetworkDefinition) -> i32 {
+        self.num_outputs(network)
     }
 
     /// See [nvinfer1::ILayer::setName]
@@ -940,9 +960,14 @@ impl NormalizationLayer<'_> {
         self.inner.as_mut().setEpsilon(eps);
     }
     /// See [nvinfer1::INormalizationLayer::getEpsilon]
-    pub fn get_epsilon(&self, network: &NetworkDefinition) -> f32 {
+    pub fn epsilon(&self, network: &NetworkDefinition) -> f32 {
         check_network!(network, self);
         self.inner.as_ref().getEpsilon()
+    }
+
+    #[deprecated = "use epsilon instead"]
+    pub fn get_epsilon(&self, network: &NetworkDefinition) -> f32 {
+        self.epsilon(network)
     }
     /// See [nvinfer1::INormalizationLayer::setAxes]
     pub fn set_axes(&mut self, network: &mut NetworkDefinition, axes: crate::Axes) {
@@ -950,9 +975,14 @@ impl NormalizationLayer<'_> {
         self.inner.as_mut().setAxes(axes.to_bits());
     }
     /// See [nvinfer1::INormalizationLayer::getAxes]
-    pub fn get_axes(&self, network: &NetworkDefinition) -> crate::Axes {
+    pub fn axes(&self, network: &NetworkDefinition) -> crate::Axes {
         check_network!(network, self);
         crate::Axes::from_bits(self.inner.as_ref().getAxes())
+    }
+
+    #[deprecated = "use axes instead"]
+    pub fn get_axes(&self, network: &NetworkDefinition) -> crate::Axes {
+        self.axes(network)
     }
     /// See [nvinfer1::INormalizationLayer::setNbGroups]
     pub fn set_num_groups(&mut self, network: &mut NetworkDefinition, groups: i64) {
@@ -960,9 +990,14 @@ impl NormalizationLayer<'_> {
         self.inner.as_mut().setNbGroups(groups);
     }
     /// See [nvinfer1::INormalizationLayer::getNbGroups]
-    pub fn get_num_groups(&self, network: &NetworkDefinition) -> i64 {
+    pub fn num_groups(&self, network: &NetworkDefinition) -> i64 {
         check_network!(network, self);
         self.inner.as_ref().getNbGroups()
+    }
+
+    #[deprecated = "use num_groups instead"]
+    pub fn get_num_groups(&self, network: &NetworkDefinition) -> i64 {
+        self.num_groups(network)
     }
 
     // is removed because deprecated in TRT
@@ -1269,17 +1304,27 @@ impl<'network> NetworkDefinition<'network> {
     }
 
     /// See [`trtx_sys::nvinfer1::INetworkDefinition::getNbInputs`].
-    pub fn get_nb_inputs(&self) -> i32 {
+    pub fn nb_inputs(&self) -> i32 {
         self.inner.getNbInputs()
     }
 
+    #[deprecated = "use nb_inputs instead"]
+    pub fn get_nb_inputs(&self) -> i32 {
+        self.nb_inputs()
+    }
+
     /// See [`trtx_sys::nvinfer1::INetworkDefinition::getNbOutputs`].
-    pub fn get_nb_outputs(&self) -> i32 {
+    pub fn nb_outputs(&self) -> i32 {
         self.inner.getNbOutputs()
     }
 
+    #[deprecated = "use nb_outputs instead"]
+    pub fn get_nb_outputs(&self) -> i32 {
+        self.nb_outputs()
+    }
+
     /// See [`trtx_sys::nvinfer1::INetworkDefinition::getInput`].
-    pub fn get_input(&self, index: i32) -> Result<Tensor<'network>> {
+    pub fn input(&self, index: i32) -> Result<Tensor<'network>> {
         let tensor_ptr = self.inner.getInput(index);
         if tensor_ptr.is_null() {
             return Err(Error::Runtime(format!(
@@ -1290,8 +1335,13 @@ impl<'network> NetworkDefinition<'network> {
         unsafe { Tensor::new(self.inner.as_ptr(), tensor_ptr) }
     }
 
+    #[deprecated = "use input instead"]
+    pub fn get_input(&self, index: i32) -> Result<Tensor<'network>> {
+        self.input(index)
+    }
+
     /// See [`trtx_sys::nvinfer1::INetworkDefinition::getOutput`].
-    pub fn get_output(&self, index: i32) -> Result<Tensor<'network>> {
+    pub fn output(&self, index: i32) -> Result<Tensor<'network>> {
         let tensor_ptr = self.inner.getOutput(index);
         if tensor_ptr.is_null() {
             return Err(Error::Runtime(format!(
@@ -1302,27 +1352,50 @@ impl<'network> NetworkDefinition<'network> {
         unsafe { Tensor::new(self.inner.as_ptr(), tensor_ptr) }
     }
 
+    #[deprecated = "use output instead"]
+    pub fn get_output(&self, index: i32) -> Result<Tensor<'network>> {
+        self.output(index)
+    }
+
     /// Number of layers in the network (for introspection/dumping).
     /// See [INetworkDefinition::getNbLayers]
-    pub fn get_nb_layers(&self) -> i32 {
+    pub fn nb_layers(&self) -> i32 {
         self.inner.getNbLayers()
     }
 
-    pub fn get_layer(&self, layer_index: i32) -> Result<DynLayer<'network>> {
+    #[deprecated = "use nb_layers instead"]
+    pub fn get_nb_layers(&self) -> i32 {
+        self.nb_layers()
+    }
+
+    pub fn layer(&self, layer_index: i32) -> Result<DynLayer<'network>> {
         let layer_ptr = self.inner.getLayer(layer_index);
         DynLayer::new_dyn(self.inner.as_ptr(), layer_ptr)
     }
 
+    #[deprecated = "use layer instead"]
+    pub fn get_layer(&self, layer_index: i32) -> Result<DynLayer<'network>> {
+        self.layer(layer_index)
+    }
+
     /// Layer name at index (for introspection/dumping). Returns "(Unnamed)" if null.
-    #[deprecated = "use network.get_layer(index)?.name(&network)"]
+    pub fn layer_name(&self, layer_index: i32) -> Result<String> {
+        Ok(self.layer(layer_index)?.name(self))
+    }
+
+    #[deprecated = "use layer_name instead"]
     pub fn get_layer_name(&self, layer_index: i32) -> Result<String> {
-        Ok(self.get_layer(layer_index)?.name(self))
+        self.layer_name(layer_index)
     }
 
     /// Layer type enum value at index (for introspection/dumping). See TensorRT LayerType.
-    #[deprecated = "use network.get_layer(index)?.layer_type_dynamic()"]
+    pub fn layer_type(&self, layer_index: i32) -> Result<LayerType> {
+        Ok(self.layer(layer_index)?.layer_type_dynamic())
+    }
+
+    #[deprecated = "use layer_type instead"]
     pub fn get_layer_type(&self, layer_index: i32) -> Result<LayerType> {
-        Ok(self.get_layer(layer_index)?.layer_type_dynamic())
+        self.layer_type(layer_index)
     }
 
     /// See [`trtx_sys::nvinfer1::INetworkDefinition::addActivation`].
@@ -1509,13 +1582,13 @@ impl<'network> NetworkDefinition<'network> {
                 weights.kernel.values,
                 weights.kernel.data_type,
             )?
-            .get_output(self, 0)?;
+            .output(self, 0)?;
         layer.set_input(self, 1, &kernel)?;
 
         if let Some(bias) = weights.bias {
             let bias = self
                 .add_constant_owned(&bias.shape, bias.values, bias.data_type)?
-                .get_output(self, 0)?;
+                .output(self, 0)?;
             layer.set_input(self, 2, &bias)?;
         }
 
@@ -1691,13 +1764,13 @@ impl<'network> NetworkDefinition<'network> {
                 weights.kernel.values,
                 weights.kernel.data_type,
             )?
-            .get_output(self, 0)?;
+            .output(self, 0)?;
         layer.set_input(self, 1, &kernel)?;
 
         if let Some(bias) = weights.bias {
             let bias = self
                 .add_constant_owned(&bias.shape, bias.values, bias.data_type)?
-                .get_output(self, 0)?;
+                .output(self, 0)?;
             layer.set_input(self, 2, &bias)?;
         }
 
@@ -1938,7 +2011,7 @@ impl<'network> NetworkDefinition<'network> {
         let axis_bytes = axis.to_le_bytes();
         let axis_constant =
             self.add_small_constant_copied(&[], &axis_bytes, trtx_sys::DataType::kINT32)?;
-        let axis_tensor = axis_constant.get_output(self, 0)?;
+        let axis_tensor = axis_constant.output(self, 0)?;
         self.add_cumulative_with_axis_tensor(input, &axis_tensor, op, exclusive, reverse)
     }
 
@@ -2417,10 +2490,15 @@ impl<'network> Attention<'network> {
     }
 
     /// See [`trtx_sys::nvinfer1::IAttention::getInput`].
-    pub fn get_input(&self, network: &NetworkDefinition, index: i32) -> Result<Tensor<'network>> {
+    pub fn input(&self, network: &NetworkDefinition, index: i32) -> Result<Tensor<'network>> {
         check_network!(network, self);
         let tensor_ptr = self.inner.getInput(index);
         unsafe { Tensor::new(self.network, tensor_ptr) }
+    }
+
+    #[deprecated = "use input instead"]
+    pub fn get_input(&self, network: &NetworkDefinition, index: i32) -> Result<Tensor<'network>> {
+        self.input(network, index)
     }
 
     /// See [`trtx_sys::nvinfer1::IAttention::getNbOutputs`].
@@ -2430,10 +2508,15 @@ impl<'network> Attention<'network> {
     }
 
     /// See [`trtx_sys::nvinfer1::IAttention::getOutput`]. IAttention has one output (index 0).
-    pub fn get_output(&self, network: &NetworkDefinition, index: i32) -> Result<Tensor<'network>> {
+    pub fn output(&self, network: &NetworkDefinition, index: i32) -> Result<Tensor<'network>> {
         check_network!(network, self);
         let tensor_ptr = self.inner.getOutput(index);
         unsafe { Tensor::new(self.network, tensor_ptr) }
+    }
+
+    #[deprecated = "use output instead"]
+    pub fn get_output(&self, network: &NetworkDefinition, index: i32) -> Result<Tensor<'network>> {
+        self.output(network, index)
     }
 
     /// See [`trtx_sys::nvinfer1::IAttention::setName`].
@@ -2499,9 +2582,14 @@ impl<'network> Attention<'network> {
     }
 
     /// See [`trtx_sys::nvinfer1::IAttention::getNormalizationQuantizeToType`].
-    pub fn get_normalization_quantize_to_type(&self, network: &NetworkDefinition) -> DataType {
+    pub fn normalization_quantize_to_type(&self, network: &NetworkDefinition) -> DataType {
         check_network!(network, self);
         self.inner.getNormalizationQuantizeToType().into()
+    }
+
+    #[deprecated = "use normalization_quantize_to_type instead"]
+    pub fn get_normalization_quantize_to_type(&self, network: &NetworkDefinition) -> DataType {
+        self.normalization_quantize_to_type(network)
     }
 
     /// See [`trtx_sys::nvinfer1::IAttention::setMetadata`].
@@ -2535,9 +2623,14 @@ impl<'network> Attention<'network> {
 
     #[cfg(feature = "v_1_4")]
     /// See [`trtx_sys::nvinfer1::IAttention::getNbRanks`].
-    pub fn get_nb_ranks(&self, network: &NetworkDefinition) -> i32 {
+    pub fn nb_ranks(&self, network: &NetworkDefinition) -> i32 {
         check_network!(network, self);
         self.inner.getNbRanks()
+    }
+
+    #[deprecated = "use nb_ranks instead"]
+    pub fn get_nb_ranks(&self, network: &NetworkDefinition) -> i32 {
+        self.nb_ranks(network)
     }
 }
 
@@ -2703,9 +2796,14 @@ impl IteratorLayer<'_> {
 
 impl LoopOutputLayer<'_> {
     /// See [`trtx_sys::nvinfer1::ILoopOutputLayer::getLoopOutput`].
-    pub fn get_loop_output(&self, network: &NetworkDefinition) -> trtx_sys::nvinfer1::LoopOutput {
+    pub fn loop_output(&self, network: &NetworkDefinition) -> trtx_sys::nvinfer1::LoopOutput {
         check_network!(network, self);
         self.inner.as_ref().getLoopOutput()
+    }
+
+    #[deprecated = "use loop_output instead"]
+    pub fn get_loop_output(&self, network: &NetworkDefinition) -> trtx_sys::nvinfer1::LoopOutput {
+        self.loop_output(network)
     }
     /// See [`trtx_sys::nvinfer1::ILoopOutputLayer::setAxis`]. Ignored if output kind is kLAST_VALUE.
     pub fn set_axis(&mut self, network: &mut NetworkDefinition, axis: i32) {
@@ -2718,9 +2816,14 @@ impl LoopOutputLayer<'_> {
 
 impl TripLimitLayer<'_> {
     /// See [`trtx_sys::nvinfer1::ITripLimitLayer::getTripLimit`].
-    pub fn get_trip_limit(&self, network: &NetworkDefinition) -> trtx_sys::nvinfer1::TripLimit {
+    pub fn trip_limit(&self, network: &NetworkDefinition) -> trtx_sys::nvinfer1::TripLimit {
         check_network!(network, self);
         self.inner.as_ref().getTripLimit()
+    }
+
+    #[deprecated = "use trip_limit instead"]
+    pub fn get_trip_limit(&self, network: &NetworkDefinition) -> trtx_sys::nvinfer1::TripLimit {
+        self.trip_limit(network)
     }
 }
 
@@ -2888,17 +2991,17 @@ mod test {
         let a = network
             .add_activation(&input, trtx_sys::ActivationType::kRELU)
             .unwrap()
-            .get_output(&network, 0)
+            .output(&network, 0)
             .unwrap();
         let b = network
             .add_activation(&a, trtx_sys::ActivationType::kRELU)
             .unwrap()
-            .get_output(&network, 0)
+            .output(&network, 0)
             .unwrap();
         let c = network
             .add_activation(&b, trtx_sys::ActivationType::kRELU)
             .unwrap()
-            .get_output(&network, 0)
+            .output(&network, 0)
             .unwrap();
         a.set_name(&mut network, "Fritz").unwrap();
         b.set_name(&mut network, "Adam").unwrap();
@@ -2906,9 +3009,9 @@ mod test {
 
         assert_eq!(
             &network
-                .get_layer(0)
+                .layer(0)
                 .unwrap()
-                .get_output(&network, 0)
+                .output(&network, 0)
                 .unwrap()
                 .name(&network)
                 .unwrap(),
@@ -2916,9 +3019,9 @@ mod test {
         );
         assert_eq!(
             &network
-                .get_layer(1)
+                .layer(1)
                 .unwrap()
-                .get_output(&network, 0)
+                .output(&network, 0)
                 .unwrap()
                 .name(&network)
                 .unwrap(),
@@ -2926,35 +3029,35 @@ mod test {
         );
         assert_eq!(
             &network
-                .get_layer(2)
+                .layer(2)
                 .unwrap()
-                .get_output(&network, 0)
+                .output(&network, 0)
                 .unwrap()
                 .name(&network)
                 .unwrap(),
             "James"
         );
         assert_eq!(
-            network.get_layer(2).unwrap().layer_type_dynamic(),
+            network.layer(2).unwrap().layer_type_dynamic(),
             LayerType::kACTIVATION
         );
         network
-            .get_layer(1)
+            .layer(1)
             .unwrap()
             .set_name(&mut network, "Eva")
             .unwrap();
         assert_eq!(
             &network
-                .get_layer(1)
+                .layer(1)
                 .unwrap()
-                .get_output(&network, 0)
+                .output(&network, 0)
                 .unwrap()
                 .name(&network)
                 .unwrap(),
             &network
-                .get_layer(2)
+                .layer(2)
                 .unwrap()
-                .get_input(&network, 0)
+                .input(&network, 0)
                 .unwrap()
                 .name(&network)
                 .unwrap(),
@@ -2962,13 +3065,13 @@ mod test {
         assert_eq!(
             "Adam",
             &network
-                .get_layer(2)
+                .layer(2)
                 .unwrap()
-                .get_input(&network, 0)
+                .input(&network, 0)
                 .unwrap()
                 .name(&network)
                 .unwrap()
         );
-        assert_eq!(&network.get_layer(1).unwrap().name(&network), "Eva");
+        assert_eq!(&network.layer(1).unwrap().name(&network), "Eva");
     }
 }

--- a/trtx/src/refitter.rs
+++ b/trtx/src/refitter.rs
@@ -130,7 +130,7 @@ impl<'logger, 'engine> Refitter<'logger, 'engine> {
     }
 
     /// Get descriptions of missing weights (layer name + role). Call with a size to limit results.
-    pub fn get_missing(&self, max_count: i32) -> Result<Vec<(String, nvinfer1::WeightsRole)>> {
+    pub fn missing(&self, max_count: i32) -> Result<Vec<(String, nvinfer1::WeightsRole)>> {
         let n = max_count.max(0) as usize;
         let mut layer_names: Vec<*const std::ffi::c_char> = vec![std::ptr::null(); n];
         let mut roles: Vec<i32> = vec![0; n];
@@ -157,8 +157,13 @@ impl<'logger, 'engine> Refitter<'logger, 'engine> {
         Ok(out)
     }
 
+    #[deprecated = "use missing instead"]
+    pub fn get_missing(&self, max_count: i32) -> Result<Vec<(String, nvinfer1::WeightsRole)>> {
+        self.missing(max_count)
+    }
+
     /// Get descriptions of all weights that could be refit (layer name + role).
-    pub fn get_all(&self, max_count: i32) -> Result<Vec<(String, nvinfer1::WeightsRole)>> {
+    pub fn all(&self, max_count: i32) -> Result<Vec<(String, nvinfer1::WeightsRole)>> {
         let n = max_count.max(0) as usize;
         let mut layer_names: Vec<*const std::ffi::c_char> = vec![std::ptr::null(); n];
         let mut roles: Vec<i32> = vec![0; n];
@@ -183,6 +188,11 @@ impl<'logger, 'engine> Refitter<'logger, 'engine> {
             out.push((s, role));
         }
         Ok(out)
+    }
+
+    #[deprecated = "use all instead"]
+    pub fn get_all(&self, max_count: i32) -> Result<Vec<(String, nvinfer1::WeightsRole)>> {
+        self.all(max_count)
     }
 
     /// See [nvinfer1::IRefitter::setErrorRecorder]
@@ -211,8 +221,13 @@ impl<'logger, 'engine> Refitter<'logger, 'engine> {
     }
 
     /// Get the assigned error recorder, or null if none.
-    pub fn get_error_recorder(&self) -> *mut nvinfer1::IErrorRecorder {
+    pub fn error_recorder(&self) -> *mut nvinfer1::IErrorRecorder {
         self.inner.getErrorRecorder()
+    }
+
+    #[deprecated = "use error_recorder instead"]
+    pub fn get_error_recorder(&self) -> *mut nvinfer1::IErrorRecorder {
+        self.error_recorder()
     }
 
     /// Specify new weights by name (host location by default).
@@ -236,7 +251,7 @@ impl<'logger, 'engine> Refitter<'logger, 'engine> {
     }
 
     /// Get names of missing weights.
-    pub fn get_missing_weights(&self, max_count: i32) -> Result<Vec<String>> {
+    pub fn missing_weights(&self, max_count: i32) -> Result<Vec<String>> {
         let n = max_count.max(0) as usize;
         let mut names: Vec<*const std::ffi::c_char> = vec![std::ptr::null(); n];
         let count = unsafe {
@@ -256,8 +271,13 @@ impl<'logger, 'engine> Refitter<'logger, 'engine> {
         Ok(out)
     }
 
+    #[deprecated = "use missing_weights instead"]
+    pub fn get_missing_weights(&self, max_count: i32) -> Result<Vec<String>> {
+        self.missing_weights(max_count)
+    }
+
     /// Get names of all weights that could be refit.
-    pub fn get_all_weights(&self, max_count: i32) -> Result<Vec<String>> {
+    pub fn all_weights(&self, max_count: i32) -> Result<Vec<String>> {
         let n = max_count.max(0) as usize;
         let mut names: Vec<*const std::ffi::c_char> = vec![std::ptr::null(); n];
         let count = unsafe {
@@ -277,14 +297,24 @@ impl<'logger, 'engine> Refitter<'logger, 'engine> {
         Ok(out)
     }
 
+    #[deprecated = "use all_weights instead"]
+    pub fn get_all_weights(&self, max_count: i32) -> Result<Vec<String>> {
+        self.all_weights(max_count)
+    }
+
     /// Raw pointer to the underlying IRefitter (for C wrappers). Caller must not use after Refitter is dropped.
     fn refitter_ptr(&self) -> *mut std::ffi::c_void {
         self.inner.as_ptr() as *mut std::ffi::c_void
     }
 
     /// Get the logger with which the refitter was created. Returns raw pointer.
-    pub fn get_logger(&self) -> *mut nvinfer1::ILogger {
+    pub fn logger(&self) -> *mut nvinfer1::ILogger {
         self.inner.getLogger()
+    }
+
+    #[deprecated = "use logger instead"]
+    pub fn get_logger(&self) -> *mut nvinfer1::ILogger {
+        self.logger()
     }
 
     /// Set the maximum number of threads used by the refitter.
@@ -297,8 +327,13 @@ impl<'logger, 'engine> Refitter<'logger, 'engine> {
     }
 
     /// Get the maximum number of threads that can be used by the refitter.
-    pub fn get_max_threads(&self) -> i32 {
+    pub fn max_threads(&self) -> i32 {
         self.inner.getMaxThreads()
+    }
+
+    #[deprecated = "use max_threads instead"]
+    pub fn get_max_threads(&self) -> i32 {
+        self.max_threads()
     }
 
     /// Specify new weights by name with explicit host/device location.
@@ -327,15 +362,25 @@ impl<'logger, 'engine> Refitter<'logger, 'engine> {
     }
 
     /// Get weights currently associated with the given name.
-    pub fn get_named_weights(&self, weights_name: &str) -> nvinfer1::Weights {
+    pub fn named_weights(&self, weights_name: &str) -> nvinfer1::Weights {
         let name_cstr = CString::new(weights_name).expect("name contains null");
         unsafe { self.inner.getNamedWeights(name_cstr.as_ptr()) }
     }
 
+    #[deprecated = "use named_weights instead"]
+    pub fn get_named_weights(&self, weights_name: &str) -> nvinfer1::Weights {
+        self.named_weights(weights_name)
+    }
+
     /// Get the location for weights associated with the given name.
-    pub fn get_weights_location(&self, weights_name: &str) -> nvinfer1::TensorLocation {
+    pub fn weights_location(&self, weights_name: &str) -> nvinfer1::TensorLocation {
         let name_cstr = CString::new(weights_name).expect("name contains null");
         unsafe { self.inner.getWeightsLocation(name_cstr.as_ptr()) }
+    }
+
+    #[deprecated = "use weights_location instead"]
+    pub fn get_weights_location(&self, weights_name: &str) -> nvinfer1::TensorLocation {
+        self.weights_location(weights_name)
     }
 
     /// Unset weights for the given name. Returns false if they were never set.
@@ -352,8 +397,13 @@ impl<'logger, 'engine> Refitter<'logger, 'engine> {
     }
 
     /// Get whether weights validation is enabled during refitting.
-    pub fn get_weights_validation(&self) -> bool {
+    pub fn weights_validation(&self) -> bool {
         self.inner.getWeightsValidation()
+    }
+
+    #[deprecated = "use weights_validation instead"]
+    pub fn get_weights_validation(&self) -> bool {
+        self.weights_validation()
     }
 
     /// Enqueue weights refitting on the given CUDA stream.
@@ -379,9 +429,14 @@ impl<'logger, 'engine> Refitter<'logger, 'engine> {
     }
 
     /// Get the weights prototype (type and count) for the given name. Values pointer is null.
-    pub fn get_weights_prototype(&self, weights_name: &str) -> nvinfer1::Weights {
+    pub fn weights_prototype(&self, weights_name: &str) -> nvinfer1::Weights {
         let name_cstr = CString::new(weights_name).expect("name contains null");
         unsafe { self.inner.getWeightsPrototype(name_cstr.as_ptr()) }
+    }
+
+    #[deprecated = "use weights_prototype instead"]
+    pub fn get_weights_prototype(&self, weights_name: &str) -> nvinfer1::Weights {
+        self.weights_prototype(weights_name)
     }
 }
 
@@ -460,7 +515,7 @@ mod tests {
         let mut const_layer = network.add_constant(&dims, weights_bytes, DataType::kFLOAT)?;
         const_layer.set_name(&mut network, "refit_const")?;
 
-        let output = const_layer.get_output(&network, 0)?;
+        let output = const_layer.output(&network, 0)?;
         output.set_name(&mut network, "output")?;
         network.mark_output(&output);
 
@@ -488,7 +543,7 @@ mod tests {
         let mut refitter = Refitter::new(&engine, &logger).expect("refitter");
 
         // Discover refittable weights
-        let all = refitter.get_all_weights(64).expect("get_all_weights");
+        let all = refitter.all_weights(64).expect("get_all_weights");
         assert!(
             !all.is_empty(),
             "engine should have at least one refittable weight (constant layer)"
@@ -496,7 +551,7 @@ mod tests {
         let weight_name = &all[0];
 
         // Prototype: type and count (values pointer is null)
-        let proto = refitter.get_weights_prototype(weight_name);
+        let proto = refitter.weights_prototype(weight_name);
         assert!(proto.count >= 0 || proto.count == -1);
         // Refit with same shape: 4 floats
         let new_vals: [f32; 4] = [10.0, 20.0, 30.0, 40.0];
@@ -524,7 +579,7 @@ mod tests {
 
         let mut refitter = Refitter::new(&engine, &logger).expect("refitter");
 
-        let weight_name = refitter.get_all_weights(64).expect("get_all_weights")[0].clone();
+        let weight_name = refitter.all_weights(64).expect("get_all_weights")[0].clone();
 
         let errors: Arc<Mutex<Vec<(ErrorCode, String)>>> = Arc::new(Mutex::new(Vec::new()));
         let recorder = Box::new(VecErrorRecorder::new(Arc::clone(&errors)));
@@ -536,7 +591,7 @@ mod tests {
         };
         let _ = refitter.set_named_weights(&weight_name, &wrong_weights);
 
-        refitter.get_named_weights("nonexistent_weight_name");
+        refitter.named_weights("nonexistent_weight_name");
 
         let collected = errors.lock().unwrap();
         assert!(

--- a/trtx/src/runtime.rs
+++ b/trtx/src/runtime.rs
@@ -136,11 +136,11 @@ mod tests {
         for i in 1..=4 {
             let one_layer =
                 network.add_small_constant_copied(&[1], &one_bytes, DataType::kFLOAT)?;
-            let one_t = one_layer.get_output(&network, 0)?;
+            let one_t = one_layer.output(&network, 0)?;
             let mut sum_layer =
                 network.add_elementwise(&tensor, &one_t, ElementWiseOperation::kSUM)?;
             sum_layer.set_name(&mut network, &format!("plus1_{}", i))?;
-            tensor = sum_layer.get_output(&network, 0)?;
+            tensor = sum_layer.output(&network, 0)?;
             let name = format!("tensor_{}", i);
             tensor.set_name(&mut network, &name)?;
             network.mark_tensor_debug(&tensor)?;
@@ -219,7 +219,7 @@ mod tests {
             conv.set_padding(&mut network, &[1i64, 1i64]);
             let name = format!("conv_out_{}", i);
             conv.set_name(&mut network, &name)?;
-            tensor = conv.get_output(&network, 0)?;
+            tensor = conv.output(&network, 0)?;
             tensor.set_name(&mut network, &name)?;
             network.mark_tensor_debug(&tensor)?;
             debug_names.push(name);
@@ -276,7 +276,7 @@ mod tests {
                 .set_tensor_address("conv_out_2", output_device.as_ptr())
                 .expect("set output");
             context
-                .enqueue_v3(crate::cuda::get_default_stream())
+                .enqueue_v3(crate::cuda::default_stream())
                 .expect("enqueue");
         }
         synchronize().expect("sync");
@@ -332,7 +332,7 @@ mod tests {
                 .set_tensor_address("tensor_4", output_device.as_ptr())
                 .expect("set output");
             context
-                .enqueue_v3(crate::cuda::get_default_stream())
+                .enqueue_v3(crate::cuda::default_stream())
                 .expect("enqueue");
         }
         synchronize().expect("sync");

--- a/trtx/src/tensor.rs
+++ b/trtx/src/tensor.rs
@@ -111,9 +111,14 @@ impl Tensor<'_> {
     }
 
     /// See [nvinfer1::ITensor::getType]
-    pub fn get_type(&self, network: &NetworkDefinition) -> DataType {
+    pub fn r#type(&self, network: &NetworkDefinition) -> DataType {
         check_network!(network, self);
         self.as_ref().getType().into()
+    }
+
+    #[deprecated = "use r#type instead"]
+    pub fn get_type(&self, network: &NetworkDefinition) -> DataType {
+        self.r#type(network)
     }
 
     /// Set allowed tensor formats (bitmask of TensorFormat). E.g. 1u32 << TensorFormat::kHWC for channels-last.

--- a/trtx/tests/test_builder_config.rs
+++ b/trtx/tests/test_builder_config.rs
@@ -23,82 +23,79 @@ mod tests {
         // Test timing iterations
         config.set_avg_timing_iterations(5);
         #[cfg(not(feature = "mock"))]
-        assert_eq!(config.get_avg_timing_iterations(), 5);
+        assert_eq!(config.avg_timing_iterations(), 5);
 
         // Test engine capability
         config.set_engine_capability(EngineCapability::kSTANDARD);
         #[cfg(not(feature = "mock"))]
-        assert_eq!(config.get_engine_capability(), EngineCapability::kSTANDARD);
+        assert_eq!(config.engine_capability(), EngineCapability::kSTANDARD);
 
         // Test flags
         config.set_flags(0);
         #[cfg(not(feature = "mock"))]
-        assert_eq!(config.get_flags(), 0);
+        assert_eq!(config.flags(), 0);
         config.set_flag(BuilderFlag::kDEBUG);
         #[cfg(not(feature = "mock"))]
-        assert!(config.get_flag(BuilderFlag::kDEBUG));
+        assert!(config.flag(BuilderFlag::kDEBUG));
         config.clear_flag(BuilderFlag::kDEBUG);
         #[cfg(not(feature = "mock"))]
-        assert!(!config.get_flag(BuilderFlag::kDEBUG));
+        assert!(!config.flag(BuilderFlag::kDEBUG));
 
         // Test DLA core
         config.set_dla_core(-1);
         #[cfg(not(feature = "mock"))]
-        assert_eq!(config.get_dla_core(), -1);
+        assert_eq!(config.dla_core(), -1);
 
         // Test device type
         config.set_default_device_type(DeviceType::kGPU);
         #[cfg(not(feature = "mock"))]
-        assert_eq!(config.get_default_device_type(), DeviceType::kGPU);
+        assert_eq!(config.default_device_type(), DeviceType::kGPU);
 
         // Test optimization profiles
-        assert_eq!(config.get_nb_optimization_profiles(), 0);
+        assert_eq!(config.nb_optimization_profiles(), 0);
 
         // Test tactic sources (kEDGE_MASK_CONVOLUTIONS = 3)
         let sources = 1u32 << 3;
         config.set_tactic_sources(sources).unwrap();
         #[cfg(not(feature = "mock"))]
-        assert_eq!(config.get_tactic_sources(), sources);
+        assert_eq!(config.tactic_sources(), sources);
 
         config.set_memory_pool_limit(MemoryPoolType::kWORKSPACE, 0);
-        let limit = config.get_memory_pool_limit(MemoryPoolType::kWORKSPACE);
+        let limit = config.memory_pool_limit(MemoryPoolType::kWORKSPACE);
         assert_eq!(limit, 0); // Default in mock
 
         // Test preview feature
         config.set_preview_feature(PreviewFeature::kALIASED_PLUGIN_IO_10_03, true);
         #[cfg(not(feature = "mock"))]
-        assert!(config.get_preview_feature(PreviewFeature::kALIASED_PLUGIN_IO_10_03));
+        assert!(config.preview_feature(PreviewFeature::kALIASED_PLUGIN_IO_10_03));
 
         // Test builder optimization level
         config.set_builder_optimization_level(5);
         #[cfg(not(feature = "mock"))]
-        assert_eq!(config.get_builder_optimization_level(), 5);
+        assert_eq!(config.builder_optimization_level(), 5);
 
         // Test hardware compatibility level
         config.set_hardware_compatibility_level(HardwareCompatibilityLevel::kNONE);
         #[cfg(not(feature = "mock"))]
         assert_eq!(
-            config.get_hardware_compatibility_level(),
+            config.hardware_compatibility_level(),
             HardwareCompatibilityLevel::kNONE
         );
 
         // Test max aux streams
         config.set_max_aux_streams(2);
         #[cfg(not(feature = "mock"))]
-        assert_eq!(config.get_max_aux_streams(), 2);
+        assert_eq!(config.max_aux_streams(), 2);
 
         // Test runtime platform
         config.set_runtime_platform(RuntimePlatform::kSAME_AS_BUILD);
         #[cfg(not(feature = "mock"))]
-        assert_eq!(
-            config.get_runtime_platform(),
-            RuntimePlatform::kSAME_AS_BUILD
-        );
+        assert_eq!(config.runtime_platform(), RuntimePlatform::kSAME_AS_BUILD);
 
         // Test max nb tactics
         config.set_max_nb_tactics(10);
         #[cfg(not(feature = "mock"))]
-        assert_eq!(config.get_max_nb_tactics(), 10);
+        assert_eq!(config.max_nb_tactics(), 10);
 
         // Test tiling optimization level
         config
@@ -106,38 +103,32 @@ mod tests {
             .unwrap();
         #[cfg(not(feature = "mock"))]
         assert_eq!(
-            config.get_tiling_optimization_level(),
+            config.tiling_optimization_level(),
             TilingOptimizationLevel::kFAST
         );
 
         // Test L2 limit for tiling
         config.set_l2_limit_for_tiling(1024).unwrap();
         #[cfg(not(feature = "mock"))]
-        assert_eq!(config.get_l2_limit_for_tiling(), 1024);
+        assert_eq!(config.l2_limit_for_tiling(), 1024);
 
         // Test compute capabilities
         #[cfg(not(feature = "enterprise"))]
         {
             config.set_nb_compute_capabilities(1).unwrap();
             #[cfg(not(feature = "mock"))]
-            assert_eq!(config.get_nb_compute_capabilities(), 1);
+            assert_eq!(config.nb_compute_capabilities(), 1);
             config
                 .set_compute_capability(ComputeCapability::kCURRENT, 0)
                 .unwrap();
             #[cfg(not(feature = "mock"))]
-            assert_eq!(
-                config.get_compute_capability(0),
-                ComputeCapability::kCURRENT
-            );
+            assert_eq!(config.compute_capability(0), ComputeCapability::kCURRENT);
         }
 
         // Test profiling verbosity
         config.set_profiling_verbosity(ProfilingVerbosity::kDETAILED);
         #[cfg(not(feature = "mock"))]
-        assert_eq!(
-            config.get_profiling_verbosity(),
-            ProfilingVerbosity::kDETAILED
-        );
+        assert_eq!(config.profiling_verbosity(), ProfilingVerbosity::kDETAILED);
 
         // Test reset
         config.reset();


### PR DESCRIPTION
Keep old method names with deprecation.

This was already done for most methods to follow
typical Rust naming conventions (most of the getters were already without get).
Do it for the rest for consistency.

Keeping this open for a while for everyone to consider