### PR TITLE
fix: return error instead of panic in `Tensor::dimensions` for negative nbDims

### DIFF
--- a/trtx/src/error.rs
+++ b/trtx/src/error.rs
@@ -120,6 +120,9 @@ pub enum Error {
 
     #[error("Failed to report to Profiler")]
     FailedToReportToProfiler,
+
+    #[error("Could not get dimensions from Tensor {tensor_name:?}")]
+    FailedToGetTensorDimensions { tensor_name: String },
 }
 
 impl<T> From<std::sync::PoisonError<T>> for Error {

--- a/trtx/src/tensor.rs
+++ b/trtx/src/tensor.rs
@@ -83,6 +83,12 @@ impl Tensor<'_> {
     pub fn dimensions(&self, network: &NetworkDefinition) -> Result<Vec<i64>> {
         check_network!(network, self);
         let result = self.as_ref().getDimensions();
+        if result.nbDims < 0 || result.nbDims >= 8 {
+            let tensor_name = self
+                .name(network)
+                .unwrap_or_else(|e| format!("<failed to get tensor name: {e}>"));
+            return Err(Error::FailedToGetTensorDimensions { tensor_name });
+        }
         Ok(result.d[..result.nbDims as usize].to_vec())
     }
 


### PR DESCRIPTION
Fixes #87