### PR TITLE
publish: bump version to 0.6.0+rtx1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0+rtx1.5] - 2026-05-28
+
+<!-- Generated using git-cliff -->
+### 🚀 Features
+
+- Add support for `ShapeLayer` (#89)
+- Debug for API facing types (#93)
+- Add RuntimeConfig, RuntimeCache (#101)
+- [**breaking**] TensorRT RTX 1.5 support, make TRT RTX 1.5 the new default (#105)
+- Export `trtx_sys` (#103)
+- Add support for AttentionIOForm, CausalMaskKind (TRT RTX 1.5) (#107)
+
+### 🐛 Bug Fixes
+
+- Return error instead of panic in `Tensor::dimensions` for negative nbDims (#90)
+- [**breaking**] Error on `false` return value for `set_{input,output}_tensor_address` (#100)
+- Manage RuntimeConfig, RuntimeCache with Arc/Rc (#102)
+
+### 💼 Other
+
+- Disable RUST_LOG during autocxx (#95)
+- Bump version to 0.6.0+rtx1.5
+
+### 🚜 Refactor
+
+- Make failed library load emit `warn` log instead of `error` (#94)
+
+### 📚 Documentation
+
+- Fix link to TRT RTX documentation in README (#97)
+- Add README for trtexec-rs (#96)
+- Document build failures with libclang >= 22 (#99)
+- Update link to Rustdoc format (#106)
+
+### ⚙️ Miscellaneous Tasks
+
+- Update actions/cache to v5 (#108)
+
+
 ## [0.5.0] - 2026-04-30
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["trtx-sys", "trtx", "trtexec-rs"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0+rtx1.5"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Tarek Ziade", "Markus Tavenrath", "Stephan Seitz"]

--- a/trtexec-rs/Cargo.toml
+++ b/trtexec-rs/Cargo.toml
@@ -9,13 +9,16 @@ repository.workspace = true
 [dependencies]
 rustnn = { git = "https://github.com/rustnn/rustnn/", features = [
 	"trtx-runtime",
-], default-features = false, branch = "main" }
+], default-features = false, branch = "v1.5-prep" }
 
 nvidia-nvtx = { version = "0.2", git = "https://github.com/NVIDIA/NVTX", branch = "release-v3" }
 log = "0.4"
 pretty_env_logger = "0.5"
-trtx = { version = "0.5.0", path = "../trtx", default-features = true }
-trtx-sys = { version = "0.5.0", path = "../trtx-sys", default-features = true }
+
+# To upgrade the trtx version to new major version, create a PR with that bump to the RustNN repo
+# and switch the RustNN dep temporarily to that branch until RustNN main has that version bump
+trtx = { version = "0.6.0", path = "../trtx", default-features = true }
+trtx-sys = { version = "0.6.0", path = "../trtx-sys", default-features = true }
 indicatif = "0.18"
 anyhow = { version = "1.0", features = ["backtrace"] }
 clap = { version = "4.6", features = ["derive"] }

--- a/trtx/Cargo.toml
+++ b/trtx/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["tensorrt", "inference", "deep-learning", "nvidia", "gpu"]
 categories = ["api-bindings", "science"]
 
 [dependencies]
-trtx-sys = { version = "0.5.0", path = "../trtx-sys", default-features = false }
+trtx-sys = { version = "0.6.0", path = "../trtx-sys", default-features = false }
 thiserror = "2.0"
 cxx = "1.0"
 libc = "0.2"


### PR DESCRIPTION
Add the `+rtx1.5` suffix to make support TRT version visible from version numbers. Such suffixes get ignored by semver resolution and are allowed by semantic versioning. An example for a suffix indicating supported Vulkan version is ash https://crates.io/crates/ash/versions