### PR TITLE
ci: pin tensorrt_rtx to exact version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
         shell: bash
         run: |
           # 1.3 is not on pip, only starting with 1.4
-          pip install tensorrt_rtx~=1.5
+          pip install tensorrt_rtx==1.5.0.114
           RTX_LIB_DIR=$(python -c 'from os.path import dirname;print(dirname(__import__("tensorrt_rtx_libs").__file__))')
           echo "RTX_LIB_DIR=$RTX_LIB_DIR"
           echo "RTX_LIB_DIR=$RTX_LIB_DIR" >> $GITHUB_ENV


### PR DESCRIPTION
Otherwise, we get upgraded to the next semver compatible version. E.g =~1.4 got resolved to 1.5.0.114 though 1.4->1.5 was a ABI break.