### PR TITLE
fix: switch trtexec-rs back to RustNN main

### DIFF
--- a/trtexec-rs/Cargo.toml
+++ b/trtexec-rs/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 [dependencies]
 rustnn = { git = "https://github.com/rustnn/rustnn/", features = [
 	"trtx-runtime",
-], default-features = false, branch = "hash-graph" }
+], default-features = false, branch = "main" }
 
 nvidia-nvtx = { version = "0.2", git = "https://github.com/NVIDIA/NVTX", branch = "release-v3" }
 log = "0.4"


### PR DESCRIPTION
The PR is now merged.

Fixes https://github.com/rustnn/trtx-rs/pull/117#issuecomment-4725682404