### PR TITLE
feat: implement `Send` for HostMemory

### DIFF
--- a/trtx/src/host_memory.rs
+++ b/trtx/src/host_memory.rs
@@ -67,3 +67,8 @@ impl<'builder> Deref for HostMemory<'builder> {
         self.as_ref()
     }
 }
+
+/// # Safety:
+///
+/// This a wrapper around C++ container on the TRT side that is safe to send to another thread
+unsafe impl Send for HostMemory<'_> {}


### PR DESCRIPTION
This allows transferring this memory to other threads, and complete thread-safety if wrapped by a Mutex.

Fixes #126 