### PR TITLE
trtexec-rs: use RustNN's new trtx-enterprise feature

### DIFF
--- a/trtexec-rs/Cargo.toml
+++ b/trtexec-rs/Cargo.toml
@@ -33,3 +33,4 @@ serde_json = "1.0"
 [features]
 default = ["rustnn"]
 rustnn = ["dep:rustnn"]
+enterprise = ["rustnn/trtx-enterprise", "trtx/enterprise"]


### PR DESCRIPTION
This allows use to compile RustNN with trtx' `enterprise` feature for validation of TRT RTX.