### PR TITLE
docs: update doc links to TensorRT RTX documentation

### DIFF
--- a/trtx/src/builder.rs
+++ b/trtx/src/builder.rs
@@ -1,6 +1,6 @@
 //! Builder for creating TensorRT engines.
 //!
-//! Wraps [`trtx_sys::nvinfer1::IBuilder`]; C++: [`nvinfer1::IBuilder`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_builder.html).
+//! Wraps [`trtx_sys::nvinfer1::IBuilder`]; C++: [`nvinfer1::IBuilder`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_builder.html).
 
 use crate::error::{Error, Result};
 use crate::host_memory::HostMemory;
@@ -30,7 +30,7 @@ pub use trtx_sys::{
 
 /// Builder for creating TensorRT engines
 ///
-/// [`trtx_sys::nvinfer1::IBuilder`] — C++ [`nvinfer1::IBuilder`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_builder.html).
+/// [`trtx_sys::nvinfer1::IBuilder`] — C++ [`nvinfer1::IBuilder`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_builder.html).
 pub struct Builder<'a> {
     inner: UniquePtr<IBuilder>,
     _logger: PhantomData<&'a Logger>,

--- a/trtx/src/builder_config.rs
+++ b/trtx/src/builder_config.rs
@@ -1,6 +1,6 @@
 //! Builder configuration for TensorRT engine builds.
 //!
-//! Wraps [`trtx_sys::nvinfer1::IBuilderConfig`]; C++: [`nvinfer1::IBuilderConfig`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_builder_config.html).
+//! Wraps [`trtx_sys::nvinfer1::IBuilderConfig`]; C++: [`nvinfer1::IBuilderConfig`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_builder_config.html).
 
 use std::marker::PhantomData;
 use std::pin::Pin;
@@ -22,7 +22,7 @@ use trtx_sys::{
 #[cfg(not(feature = "enterprise"))]
 use trtx_sys::ComputeCapability;
 
-/// [`trtx_sys::nvinfer1::IBuilderConfig`] — C++ [`nvinfer1::IBuilderConfig`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_builder_config.html).
+/// [`trtx_sys::nvinfer1::IBuilderConfig`] — C++ [`nvinfer1::IBuilderConfig`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_builder_config.html).
 pub struct BuilderConfig<'builder> {
     pub(crate) inner: UniquePtr<IBuilderConfig>,
     progress_monitor: Option<Pin<Box<ProgressMonitor>>>,

--- a/trtx/src/cuda_engine.rs
+++ b/trtx/src/cuda_engine.rs
@@ -1,7 +1,7 @@
 //! CUDA engine and serialization config.
 //!
-//! [`CudaEngine`] wraps [`nvinfer1::ICudaEngine`] (C++ [`nvinfer1::ICudaEngine`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_cuda_engine.html)).
-//! [`SerializationConfig`] wraps [`nvinfer1::ISerializationConfig`] (C++ [`nvinfer1::ISerializationConfig`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_serialization_config.html)).
+//! [`CudaEngine`] wraps [`nvinfer1::ICudaEngine`] (C++ [`nvinfer1::ICudaEngine`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_cuda_engine.html)).
+//! [`SerializationConfig`] wraps [`nvinfer1::ISerializationConfig`] (C++ [`nvinfer1::ISerializationConfig`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_serialization_config.html)).
 
 use std::rc::Rc;
 #[cfg(all(feature = "v_1_6", not(feature = "enterprise")))]
@@ -22,7 +22,7 @@ use trtx_sys::{
 };
 use trtx_sys::{TensorFormat, TensorLocation};
 
-/// [`nvinfer1::ISerializationConfig`] — C++ [`nvinfer1::ISerializationConfig`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_serialization_config.html).
+/// [`nvinfer1::ISerializationConfig`] — C++ [`nvinfer1::ISerializationConfig`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_serialization_config.html).
 pub struct SerializationConfig<'cuda_engine> {
     inner: UniquePtr<nvinfer1::ISerializationConfig>,
     _runtime: PhantomData<&'cuda_engine nvinfer1::ICudaEngine>,
@@ -76,7 +76,7 @@ impl SerializationConfig<'_> {
     }
 }
 
-/// [nvinfer1::ICudaEngine] — C++ [`nvinfer1::ICudaEngine`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_cuda_engine.html).
+/// [nvinfer1::ICudaEngine] — C++ [`nvinfer1::ICudaEngine`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_cuda_engine.html).
 pub struct CudaEngine<'runtime> {
     pub(crate) inner: UniquePtr<ICudaEngine>,
     _runtime: PhantomData<&'runtime nvinfer1::IRuntime>,

--- a/trtx/src/engine_inspector.rs
+++ b/trtx/src/engine_inspector.rs
@@ -1,6 +1,6 @@
 //! Engine inspector (layer / engine introspection as text or JSON).
 //!
-//! [`EngineInspector`] wraps [`trtx_sys::nvinfer1::IEngineInspector`] (C++ [`nvinfer1::IEngineInspector`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_engine_inspector.html)).
+//! [`EngineInspector`] wraps [`trtx_sys::nvinfer1::IEngineInspector`] (C++ [`nvinfer1::IEngineInspector`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_engine_inspector.html)).
 
 use crate::{Error, Result};
 use std::{ffi::CStr, marker::PhantomData};
@@ -8,7 +8,7 @@ use std::{ffi::CStr, marker::PhantomData};
 use autocxx::cxx::UniquePtr;
 use trtx_sys::{nvinfer1, LayerInformationFormat};
 
-/// [`trtx_sys::nvinfer1::IEngineInspector`] — C++ [`nvinfer1::IEngineInspector`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_engine_inspector.html).
+/// [`trtx_sys::nvinfer1::IEngineInspector`] — C++ [`nvinfer1::IEngineInspector`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_engine_inspector.html).
 pub struct EngineInspector<'engine> {
     pub(crate) inner: UniquePtr<nvinfer1::IEngineInspector>,
     pub(crate) _engine: PhantomData<&'engine nvinfer1::ICudaEngine>,

--- a/trtx/src/execution_context.rs
+++ b/trtx/src/execution_context.rs
@@ -13,7 +13,7 @@ use crate::interfaces::{
 };
 use crate::RuntimeConfig;
 
-/// [`trtx_sys::nvinfer1::IExecutionContext`] — C++ [`nvinfer1::IExecutionContext`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_execution_context.html).
+/// [`trtx_sys::nvinfer1::IExecutionContext`] — C++ [`nvinfer1::IExecutionContext`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_execution_context.html).
 ///
 /// `inner` is declared last so it is dropped first (see [`Drop`]): TensorRT must release
 /// [DebugListener] / [Profiler]

--- a/trtx/src/executor.rs
+++ b/trtx/src/executor.rs
@@ -3,7 +3,7 @@
 //! This module orchestrates [`crate::Builder`], [`crate::OnnxParser`], [`crate::Runtime`], and
 //! [`crate::CudaEngine`], which wrap [`trtx_sys::nvinfer1::IBuilder`], [`trtx_sys::nvonnxparser::IParser`],
 //! [`trtx_sys::nvinfer1::IRuntime`], and [`trtx_sys::nvinfer1::ICudaEngine`]. See the
-//! [TensorRT for RTX C++ API](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/annotated.html).
+//! [TensorRT for RTX C++ API](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/annotated.html).
 
 use crate::builder::network_flags;
 use crate::error::Result;

--- a/trtx/src/host_memory.rs
+++ b/trtx/src/host_memory.rs
@@ -1,6 +1,6 @@
 //! Host memory buffer returned by the TensorRT builder (serialized engines, etc.).
 //!
-//! [`HostMemory`] wraps [`trtx_sys::nvinfer1::IHostMemory`] (C++ [`nvinfer1::IHostMemory`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_host_memory.html)).
+//! [`HostMemory`] wraps [`trtx_sys::nvinfer1::IHostMemory`] (C++ [`nvinfer1::IHostMemory`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_host_memory.html)).
 
 use core::slice;
 use cxx::UniquePtr;
@@ -9,7 +9,7 @@ use std::ops::Deref;
 use trtx_sys::nvinfer1::{self};
 use trtx_sys::DataType;
 
-/// [`trtx_sys::nvinfer1::IHostMemory`] — C++ [`nvinfer1::IHostMemory`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_host_memory.html).
+/// [`trtx_sys::nvinfer1::IHostMemory`] — C++ [`nvinfer1::IHostMemory`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_host_memory.html).
 pub struct HostMemory<'builder> {
     pub(crate) inner: UniquePtr<nvinfer1::IHostMemory>,
     _builder: PhantomData<&'builder nvinfer1::IBuilder>,

--- a/trtx/src/interfaces.rs
+++ b/trtx/src/interfaces.rs
@@ -1,7 +1,7 @@
 //! Rust implementations of TensorRT callback / allocator interfaces (bridged to C++).
 //!
 //! Versioned runtime interfaces live under `nvinfer1::v_1_0` in C++; see the
-//! [annotated class list](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/annotated.html).
+//! [annotated class list](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/annotated.html).
 
 use crate::{Error, Result};
 use cxx::UniquePtr;
@@ -14,15 +14,15 @@ use trtx_sys::{
 };
 use trtx_sys::{DataType, Dims64, ErrorCode, SeekPosition, TensorLocation};
 
-/// Rust trait implemented by [`ProgressMonitor`] for [`trtx_sys::nvinfer1::IProgressMonitor`]; C++ [`nvinfer1::v_1_0::IProgressMonitor`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1v__1__0_1_1_i_progress_monitor.html).
+/// Rust trait implemented by [`ProgressMonitor`] for [`trtx_sys::nvinfer1::IProgressMonitor`]; C++ [`nvinfer1::v_1_0::IProgressMonitor`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1v__1__0_1_1_i_progress_monitor.html).
 ///
 /// Use with [`crate::BuilderConfig::set_progress_monitor`].
 pub trait MonitorProgress: Send + Sync {
-    /// See [`trtx_sys::nvinfer1::IProgressMonitor`] / C++ [`phaseStart`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1v__1__0_1_1_i_progress_monitor.html).
+    /// See [`trtx_sys::nvinfer1::IProgressMonitor`] / C++ [`phaseStart`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1v__1__0_1_1_i_progress_monitor.html).
     fn phase_start(&self, phase_name: &str, parent_phase: Option<&str>, num_steps: i32);
-    /// See [`trtx_sys::nvinfer1::IProgressMonitor`] / C++ [`stepComplete`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1v__1__0_1_1_i_progress_monitor.html). Return whether to continue building or cancel.
+    /// See [`trtx_sys::nvinfer1::IProgressMonitor`] / C++ [`stepComplete`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1v__1__0_1_1_i_progress_monitor.html). Return whether to continue building or cancel.
     fn step_complete(&self, phase_name: &str, step: i32) -> std::ops::ControlFlow<()>;
-    /// See [`trtx_sys::nvinfer1::IProgressMonitor`] / C++ [`phaseFinish`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1v__1__0_1_1_i_progress_monitor.html).
+    /// See [`trtx_sys::nvinfer1::IProgressMonitor`] / C++ [`phaseFinish`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1v__1__0_1_1_i_progress_monitor.html).
     fn phase_finish(&self, phase_name: &str);
 }
 
@@ -70,7 +70,7 @@ unsafe extern "system" fn ProgressMonitor_phaseFinish(
         .phase_finish(&phase_name.to_string_lossy());
 }
 
-/// Bridges to [`trtx_sys::nvinfer1::IProgressMonitor`]; C++ [`nvinfer1::v_1_0::IProgressMonitor`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1v__1__0_1_1_i_progress_monitor.html).
+/// Bridges to [`trtx_sys::nvinfer1::IProgressMonitor`]; C++ [`nvinfer1::v_1_0::IProgressMonitor`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1v__1__0_1_1_i_progress_monitor.html).
 ///
 /// Construct with a [`MonitorProgress`] implementation.
 #[repr(C)]
@@ -276,7 +276,7 @@ unsafe extern "system" fn GpuAllocator_deallocateAsync(
         .deallocate_async(memory, cuda_stream)
 }
 
-/// Bridges to [`trtx_sys::nvinfer1::IGpuAllocator`]; C++ [`nvinfer1::v_1_0::IGpuAllocator`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1v__1__0_1_1_i_gpu_allocator.html).
+/// Bridges to [`trtx_sys::nvinfer1::IGpuAllocator`]; C++ [`nvinfer1::v_1_0::IGpuAllocator`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1v__1__0_1_1_i_gpu_allocator.html).
 ///
 /// Construct with an [`AllocateGpu`] implementation.
 #[repr(C)]
@@ -321,7 +321,7 @@ impl GpuAllocator {
     }
 }
 
-/// Implemented by [`GpuAllocator`] for [`trtx_sys::nvinfer1::IGpuAllocator`]; C++ [`nvinfer1::v_1_0::IGpuAllocator`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1v__1__0_1_1_i_gpu_allocator.html).
+/// Implemented by [`GpuAllocator`] for [`trtx_sys::nvinfer1::IGpuAllocator`]; C++ [`nvinfer1::v_1_0::IGpuAllocator`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1v__1__0_1_1_i_gpu_allocator.html).
 pub trait AllocateGpu: Send + Sync {
     // we omit the following deprecated methods
     //fn allocate(&mut self, size: u64, alignment: u64, flags: u32) -> *mut autocxx::c_void;
@@ -425,7 +425,7 @@ unsafe extern "system" fn ErrorRecorder_decRefCount(this: *mut ErrorRecorder) ->
     this.as_mut().unwrap().rust_impl.dec_ref_count()
 }
 
-/// Bridges to [`trtx_sys::nvinfer1::IErrorRecorder`]; C++ [`nvinfer1::v_1_0::IErrorRecorder`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1v__1__0_1_1_i_error_recorder.html).
+/// Bridges to [`trtx_sys::nvinfer1::IErrorRecorder`]; C++ [`nvinfer1::v_1_0::IErrorRecorder`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1v__1__0_1_1_i_error_recorder.html).
 ///
 /// Construct with a [`RecordError`] implementation.
 #[repr(C)]
@@ -483,7 +483,7 @@ impl ErrorRecorder {
     }
 }
 
-/// Implemented by [`ErrorRecorder`] for [`trtx_sys::nvinfer1::IErrorRecorder`]; C++ [`nvinfer1::v_1_0::IErrorRecorder`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1v__1__0_1_1_i_error_recorder.html).
+/// Implemented by [`ErrorRecorder`] for [`trtx_sys::nvinfer1::IErrorRecorder`]; C++ [`nvinfer1::v_1_0::IErrorRecorder`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1v__1__0_1_1_i_error_recorder.html).
 pub trait RecordError: Send + Sync {
     fn nb_errors(&self) -> i32;
     fn error_code(&self, error_idx: i32) -> ErrorCode;
@@ -522,7 +522,7 @@ unsafe extern "system" fn DebugListener_processDebugTensor(
         .is_ok()
 }
 
-/// Bridges to [`trtx_sys::nvinfer1::IDebugListener`]; C++ [`nvinfer1::v_1_0::IDebugListener`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1v__1__0_1_1_i_debug_listener.html).
+/// Bridges to [`trtx_sys::nvinfer1::IDebugListener`]; C++ [`nvinfer1::v_1_0::IDebugListener`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1v__1__0_1_1_i_debug_listener.html).
 #[repr(C)]
 pub struct DebugListener {
     cpp_obj: *mut nvinfer1::IDebugListener,
@@ -566,7 +566,7 @@ impl DebugListener {
     }
 }
 
-/// Implemented by [`DebugListener`] for [`trtx_sys::nvinfer1::IDebugListener`] (`processDebugTensor`); C++ [`nvinfer1::v_1_0::IDebugListener`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1v__1__0_1_1_i_debug_listener.html).
+/// Implemented by [`DebugListener`] for [`trtx_sys::nvinfer1::IDebugListener`] (`processDebugTensor`); C++ [`nvinfer1::v_1_0::IDebugListener`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1v__1__0_1_1_i_debug_listener.html).
 pub trait ProcessDebugTensor: Send + Sync {
     /// # Safety
     ///
@@ -602,7 +602,7 @@ unsafe extern "system" fn Profiler_reportLayerTime(
         .report_layer_time(name.as_ref(), ms);
 }
 
-/// Bridges to [`trtx_sys::nvinfer1::IProfiler`]; C++ [`nvinfer1::v_1_0::IProfiler`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1v__1__0_1_1_i_profiler.html).
+/// Bridges to [`trtx_sys::nvinfer1::IProfiler`]; C++ [`nvinfer1::v_1_0::IProfiler`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1v__1__0_1_1_i_profiler.html).
 #[repr(C)]
 pub struct Profiler {
     cpp_obj: *mut nvinfer1::IProfiler,
@@ -654,7 +654,7 @@ impl Drop for Profiler {
     }
 }
 
-/// Implemented by [`Profiler`] for [`trtx_sys::nvinfer1::IProfiler`] (`reportLayerTime`); C++ [`nvinfer1::v_1_0::IProfiler`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1v__1__0_1_1_i_profiler.html).
+/// Implemented by [`Profiler`] for [`trtx_sys::nvinfer1::IProfiler`] (`reportLayerTime`); C++ [`nvinfer1::v_1_0::IProfiler`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1v__1__0_1_1_i_profiler.html).
 pub trait ReportLayerTime: Send + Sync {
     /// Layer name from the network (or a decimal layer index if the engine was built with profiling
     /// verbosity [`crate::ProfilingVerbosity::kNONE`]). `ms` is execution time for that layer in

--- a/trtx/src/lib.rs
+++ b/trtx/src/lib.rs
@@ -116,7 +116,7 @@
 //!
 //! Rust types in this crate wrap TensorRT for RTX C++ interfaces. The authoritative class list and
 //! method documentation is the
-//! [TensorRT for RTX C++ API (annotated)](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/annotated.html).
+//! [TensorRT for RTX C++ API (annotated)](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/annotated.html).
 //! Each wrapper’s docs also link the Rust FFI type in [`trtx_sys::nvinfer1`] or [`trtx_sys::nvonnxparser`]
 //! alongside the matching C++ class on NVIDIA’s site.
 

--- a/trtx/src/logger.rs
+++ b/trtx/src/logger.rs
@@ -1,6 +1,6 @@
 //! Logger interface for TensorRT-RTX.
 //!
-//! [`Logger`] bridges to [`trtx_sys::nvinfer1::ILogger`] for the C++ API (see C++ [`nvinfer1::ILogger`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_logger.html)).
+//! [`Logger`] bridges to [`trtx_sys::nvinfer1::ILogger`] for the C++ API (see C++ [`nvinfer1::ILogger`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1v__1__0_1_1_i_logger.html)).
 
 /// Severity level for log messages
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -51,7 +51,7 @@ impl LogHandler for LogCrateLogger {
 
 /// Logger (uses Rust bridge to TensorRT)
 ///
-/// Implements the callback side of [`trtx_sys::nvinfer1::ILogger`] via the Rust bridge; C++ [`nvinfer1::ILogger`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_logger.html).
+/// Implements the callback side of [`trtx_sys::nvinfer1::ILogger`] via the Rust bridge; C++ [`nvinfer1::ILogger`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1v__1__0_1_1_i_logger.html).
 pub struct Logger {
     bridge: *mut trtx_sys::RustLoggerBridge,
     user_data: *mut std::ffi::c_void,

--- a/trtx/src/network.rs
+++ b/trtx/src/network.rs
@@ -1,8 +1,8 @@
 //! Network definition for building TensorRT engines.
 //!
-//! [`NetworkDefinition`] holds [`trtx_sys::nvinfer1::INetworkDefinition`] (C++ [`nvinfer1::INetworkDefinition`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_network_definition.html)).
-//! [`Tensor`] wraps [`trtx_sys::nvinfer1::ITensor`] (C++ [`nvinfer1::ITensor`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_tensor.html)).
-//! Layer handles implement [`trtx_sys::AsLayer`] / [`trtx_sys::AsLayerTyped`] over concrete `trtx_sys::nvinfer1::I*Layer` types; C++ index: [annotated](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/annotated.html).
+//! [`NetworkDefinition`] holds [`trtx_sys::nvinfer1::INetworkDefinition`] (C++ [`nvinfer1::INetworkDefinition`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_network_definition.html)).
+//! [`Tensor`] wraps [`trtx_sys::nvinfer1::ITensor`] (C++ [`nvinfer1::ITensor`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_tensor.html)).
+//! Layer handles implement [`trtx_sys::AsLayer`] / [`trtx_sys::AsLayerTyped`] over concrete `trtx_sys::nvinfer1::I*Layer` types; C++ index: [annotated](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/annotated.html).
 
 use crate::interfaces::RecordError;
 pub use crate::tensor::Tensor;
@@ -79,7 +79,7 @@ impl OwnedConvWeights {
     }
 }
 
-/// `Inner` is a concrete [`trtx_sys::nvinfer1`] `I*Layer` (all implement [`trtx_sys::AsLayer`] toward [`trtx_sys::nvinfer1::ILayer`]); C++ base [`nvinfer1::ILayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_layer.html).
+/// `Inner` is a concrete [`trtx_sys::nvinfer1`] `I*Layer` (all implement [`trtx_sys::AsLayer`] toward [`trtx_sys::nvinfer1::ILayer`]); C++ base [`nvinfer1::ILayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_layer.html).
 pub struct Layer<'network, Inner: AsLayer> {
     pub(crate) inner: Pin<&'network mut Inner>,
     pub(crate) network: *const nvinfer1::INetworkDefinition,
@@ -240,123 +240,123 @@ impl<'network, Inner: AsLayer> Layer<'network, Inner> {
     }
 }
 
-/// [`trtx_sys::nvinfer1::IActivationLayer`] — C++ [`nvinfer1::IActivationLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_activation_layer.html).
+/// [`trtx_sys::nvinfer1::IActivationLayer`] — C++ [`nvinfer1::IActivationLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_activation_layer.html).
 pub type ActivationLayer<'layer> = Layer<'layer, nvinfer1::IActivationLayer>;
-/// [`trtx_sys::nvinfer1::IAssertionLayer`] — C++ [`nvinfer1::IAssertionLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_assertion_layer.html).
+/// [`trtx_sys::nvinfer1::IAssertionLayer`] — C++ [`nvinfer1::IAssertionLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_assertion_layer.html).
 pub type AssertionLayer<'layer> = Layer<'layer, nvinfer1::IAssertionLayer>;
-/// [`trtx_sys::nvinfer1::ICastLayer`] — C++ [`nvinfer1::ICastLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_cast_layer.html).
+/// [`trtx_sys::nvinfer1::ICastLayer`] — C++ [`nvinfer1::ICastLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_cast_layer.html).
 pub type CastLayer<'layer> = Layer<'layer, nvinfer1::ICastLayer>;
-/// [`trtx_sys::nvinfer1::IConcatenationLayer`] — C++ [`nvinfer1::IConcatenationLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_concatenation_layer.html).
+/// [`trtx_sys::nvinfer1::IConcatenationLayer`] — C++ [`nvinfer1::IConcatenationLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_concatenation_layer.html).
 pub type ConcatenationLayer<'layer> = Layer<'layer, nvinfer1::IConcatenationLayer>;
-/// [`trtx_sys::nvinfer1::IConstantLayer`] — C++ [`nvinfer1::IConstantLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_constant_layer.html).
+/// [`trtx_sys::nvinfer1::IConstantLayer`] — C++ [`nvinfer1::IConstantLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_constant_layer.html).
 pub type ConstantLayer<'layer> = Layer<'layer, nvinfer1::IConstantLayer>;
-/// [`trtx_sys::nvinfer1::IConvolutionLayer`] — C++ [`nvinfer1::IConvolutionLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_convolution_layer.html).
+/// [`trtx_sys::nvinfer1::IConvolutionLayer`] — C++ [`nvinfer1::IConvolutionLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_convolution_layer.html).
 pub type ConvolutionLayer<'layer> = Layer<'layer, nvinfer1::IConvolutionLayer>;
-/// [`trtx_sys::nvinfer1::ICumulativeLayer`] — C++ [`nvinfer1::ICumulativeLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_cumulative_layer.html).
+/// [`trtx_sys::nvinfer1::ICumulativeLayer`] — C++ [`nvinfer1::ICumulativeLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_cumulative_layer.html).
 pub type CumulativeLayer<'layer> = Layer<'layer, nvinfer1::ICumulativeLayer>;
-/// [`trtx_sys::nvinfer1::IDeconvolutionLayer`] — C++ [`nvinfer1::IDeconvolutionLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_deconvolution_layer.html).
+/// [`trtx_sys::nvinfer1::IDeconvolutionLayer`] — C++ [`nvinfer1::IDeconvolutionLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_deconvolution_layer.html).
 pub type DeconvolutionLayer<'layer> = Layer<'layer, nvinfer1::IDeconvolutionLayer>;
-/// [`trtx_sys::nvinfer1::IDequantizeLayer`] — C++ [`nvinfer1::IDequantizeLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_dequantize_layer.html).
+/// [`trtx_sys::nvinfer1::IDequantizeLayer`] — C++ [`nvinfer1::IDequantizeLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_dequantize_layer.html).
 pub type DequantizeLayer<'layer> = Layer<'layer, nvinfer1::IDequantizeLayer>;
-/// [`trtx_sys::nvinfer1::IDynamicQuantizeLayer`] — C++ [`nvinfer1::IDynamicQuantizeLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_dynamic_quantize_layer.html).
+/// [`trtx_sys::nvinfer1::IDynamicQuantizeLayer`] — C++ [`nvinfer1::IDynamicQuantizeLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_dynamic_quantize_layer.html).
 pub type DynamicQuantizeLayer<'layer> = Layer<'layer, nvinfer1::IDynamicQuantizeLayer>;
-/// [`trtx_sys::nvinfer1::IElementWiseLayer`] — C++ [`nvinfer1::IElementWiseLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_element_wise_layer.html).
+/// [`trtx_sys::nvinfer1::IElementWiseLayer`] — C++ [`nvinfer1::IElementWiseLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_element_wise_layer.html).
 pub type ElementWiseLayer<'layer> = Layer<'layer, nvinfer1::IElementWiseLayer>;
-/// [`trtx_sys::nvinfer1::IEinsumLayer`] — C++ [`nvinfer1::IEinsumLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_einsum_layer.html).
+/// [`trtx_sys::nvinfer1::IEinsumLayer`] — C++ [`nvinfer1::IEinsumLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_einsum_layer.html).
 pub type EinsumLayer<'layer> = Layer<'layer, nvinfer1::IEinsumLayer>;
-/// [`trtx_sys::nvinfer1::IFillLayer`] — C++ [`nvinfer1::IFillLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_fill_layer.html).
+/// [`trtx_sys::nvinfer1::IFillLayer`] — C++ [`nvinfer1::IFillLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_fill_layer.html).
 pub type FillLayer<'layer> = Layer<'layer, nvinfer1::IFillLayer>;
-/// [`trtx_sys::nvinfer1::IGatherLayer`] — C++ [`nvinfer1::IGatherLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_gather_layer.html).
+/// [`trtx_sys::nvinfer1::IGatherLayer`] — C++ [`nvinfer1::IGatherLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_gather_layer.html).
 pub type GatherLayer<'layer> = Layer<'layer, nvinfer1::IGatherLayer>;
-/// [`trtx_sys::nvinfer1::IGridSampleLayer`] — C++ [`nvinfer1::IGridSampleLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_grid_sample_layer.html).
+/// [`trtx_sys::nvinfer1::IGridSampleLayer`] — C++ [`nvinfer1::IGridSampleLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_grid_sample_layer.html).
 pub type GridSampleLayer<'layer> = Layer<'layer, nvinfer1::IGridSampleLayer>;
-/// [`trtx_sys::nvinfer1::IIdentityLayer`] — C++ [`nvinfer1::IIdentityLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_identity_layer.html).
+/// [`trtx_sys::nvinfer1::IIdentityLayer`] — C++ [`nvinfer1::IIdentityLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_identity_layer.html).
 pub type IdentityLayer<'layer> = Layer<'layer, nvinfer1::IIdentityLayer>;
-/// [`trtx_sys::nvinfer1::IMatrixMultiplyLayer`] — C++ [`nvinfer1::IMatrixMultiplyLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_matrix_multiply_layer.html).
+/// [`trtx_sys::nvinfer1::IMatrixMultiplyLayer`] — C++ [`nvinfer1::IMatrixMultiplyLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_matrix_multiply_layer.html).
 pub type MatrixMultiplyLayer<'layer> = Layer<'layer, nvinfer1::IMatrixMultiplyLayer>;
-/// [`trtx_sys::nvinfer1::INMSLayer`] — C++ [`nvinfer1::INMSLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_n_m_s_layer.html).
+/// [`trtx_sys::nvinfer1::INMSLayer`] — C++ [`nvinfer1::INMSLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_n_m_s_layer.html).
 pub type NMSLayer<'layer> = Layer<'layer, nvinfer1::INMSLayer>;
-/// [`trtx_sys::nvinfer1::INonZeroLayer`] — C++ [`nvinfer1::INonZeroLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_non_zero_layer.html).
+/// [`trtx_sys::nvinfer1::INonZeroLayer`] — C++ [`nvinfer1::INonZeroLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_non_zero_layer.html).
 pub type NonZeroLayer<'layer> = Layer<'layer, nvinfer1::INonZeroLayer>;
-/// [`trtx_sys::nvinfer1::INormalizationLayer`] — C++ [`nvinfer1::INormalizationLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_normalization_layer.html).
+/// [`trtx_sys::nvinfer1::INormalizationLayer`] — C++ [`nvinfer1::INormalizationLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_normalization_layer.html).
 pub type NormalizationLayer<'layer> = Layer<'layer, nvinfer1::INormalizationLayer>;
-/// [`trtx_sys::nvinfer1::IPaddingLayer`] — C++ [`nvinfer1::IPaddingLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_padding_layer.html).
+/// [`trtx_sys::nvinfer1::IPaddingLayer`] — C++ [`nvinfer1::IPaddingLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_padding_layer.html).
 pub type PaddingLayer<'layer> = Layer<'layer, nvinfer1::IPaddingLayer>;
-/// [`trtx_sys::nvinfer1::IParametricReLULayer`] — C++ [`nvinfer1::IParametricReLULayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_parametric_re_l_u_layer.html).
+/// [`trtx_sys::nvinfer1::IParametricReLULayer`] — C++ [`nvinfer1::IParametricReLULayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_parametric_re_l_u_layer.html).
 pub type ParametricReLULayer<'layer> = Layer<'layer, nvinfer1::IParametricReLULayer>;
-/// [`trtx_sys::nvinfer1::IPoolingLayer`] — C++ [`nvinfer1::IPoolingLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_pooling_layer.html).
+/// [`trtx_sys::nvinfer1::IPoolingLayer`] — C++ [`nvinfer1::IPoolingLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_pooling_layer.html).
 pub type PoolingLayer<'layer> = Layer<'layer, nvinfer1::IPoolingLayer>;
-/// [`trtx_sys::nvinfer1::IQuantizeLayer`] — C++ [`nvinfer1::IQuantizeLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_quantize_layer.html).
+/// [`trtx_sys::nvinfer1::IQuantizeLayer`] — C++ [`nvinfer1::IQuantizeLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_quantize_layer.html).
 pub type QuantizeLayer<'layer> = Layer<'layer, nvinfer1::IQuantizeLayer>;
-/// [`trtx_sys::nvinfer1::IRaggedSoftMaxLayer`] — C++ [`nvinfer1::IRaggedSoftMaxLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_ragged_soft_max_layer.html).
+/// [`trtx_sys::nvinfer1::IRaggedSoftMaxLayer`] — C++ [`nvinfer1::IRaggedSoftMaxLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_ragged_soft_max_layer.html).
 pub type RaggedSoftMaxLayer<'layer> = Layer<'layer, nvinfer1::IRaggedSoftMaxLayer>;
-/// [`trtx_sys::nvinfer1::IReduceLayer`] — C++ [`nvinfer1::IReduceLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_reduce_layer.html).
+/// [`trtx_sys::nvinfer1::IReduceLayer`] — C++ [`nvinfer1::IReduceLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_reduce_layer.html).
 pub type ReduceLayer<'layer> = Layer<'layer, nvinfer1::IReduceLayer>;
-/// [`trtx_sys::nvinfer1::IResizeLayer`] — C++ [`nvinfer1::IResizeLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_resize_layer.html).
+/// [`trtx_sys::nvinfer1::IResizeLayer`] — C++ [`nvinfer1::IResizeLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_resize_layer.html).
 pub type ResizeLayer<'layer> = Layer<'layer, nvinfer1::IResizeLayer>;
-/// [`trtx_sys::nvinfer1::IRotaryEmbeddingLayer`] — C++ [`nvinfer1::IRotaryEmbeddingLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_rotary_embedding_layer.html).
+/// [`trtx_sys::nvinfer1::IRotaryEmbeddingLayer`] — C++ [`nvinfer1::IRotaryEmbeddingLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_rotary_embedding_layer.html).
 pub type RotaryEmbeddingLayer<'layer> = Layer<'layer, nvinfer1::IRotaryEmbeddingLayer>;
-/// [`trtx_sys::nvinfer1::IScaleLayer`] — C++ [`nvinfer1::IScaleLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_scale_layer.html).
+/// [`trtx_sys::nvinfer1::IScaleLayer`] — C++ [`nvinfer1::IScaleLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_scale_layer.html).
 pub type ScaleLayer<'layer> = Layer<'layer, nvinfer1::IScaleLayer>;
-/// [`trtx_sys::nvinfer1::IScatterLayer`] — C++ [`nvinfer1::IScatterLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_scatter_layer.html).
+/// [`trtx_sys::nvinfer1::IScatterLayer`] — C++ [`nvinfer1::IScatterLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_scatter_layer.html).
 pub type ScatterLayer<'layer> = Layer<'layer, nvinfer1::IScatterLayer>;
-/// [`trtx_sys::nvinfer1::ISelectLayer`] — C++ [`nvinfer1::ISelectLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_select_layer.html).
+/// [`trtx_sys::nvinfer1::ISelectLayer`] — C++ [`nvinfer1::ISelectLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_select_layer.html).
 pub type SelectLayer<'layer> = Layer<'layer, nvinfer1::ISelectLayer>;
-/// [`trtx_sys::nvinfer1::IShapeLayer`] — C++ [`nvinfer1::IShapeLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_shape_layer.html).
+/// [`trtx_sys::nvinfer1::IShapeLayer`] — C++ [`nvinfer1::IShapeLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_shape_layer.html).
 pub type ShapeLayer<'layer> = Layer<'layer, nvinfer1::IShapeLayer>;
-/// [`trtx_sys::nvinfer1::IShuffleLayer`] — C++ [`nvinfer1::IShuffleLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_shuffle_layer.html).
+/// [`trtx_sys::nvinfer1::IShuffleLayer`] — C++ [`nvinfer1::IShuffleLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_shuffle_layer.html).
 pub type ShuffleLayer<'layer> = Layer<'layer, nvinfer1::IShuffleLayer>;
-/// [`trtx_sys::nvinfer1::ISliceLayer`] — C++ [`nvinfer1::ISliceLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_slice_layer.html).
+/// [`trtx_sys::nvinfer1::ISliceLayer`] — C++ [`nvinfer1::ISliceLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_slice_layer.html).
 pub type SliceLayer<'layer> = Layer<'layer, nvinfer1::ISliceLayer>;
-/// [`trtx_sys::nvinfer1::ISoftMaxLayer`] — C++ [`nvinfer1::ISoftMaxLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_soft_max_layer.html).
+/// [`trtx_sys::nvinfer1::ISoftMaxLayer`] — C++ [`nvinfer1::ISoftMaxLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_soft_max_layer.html).
 pub type SoftMaxLayer<'layer> = Layer<'layer, nvinfer1::ISoftMaxLayer>;
-/// [`trtx_sys::nvinfer1::ISqueezeLayer`] — C++ [`nvinfer1::ISqueezeLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_squeeze_layer.html).
+/// [`trtx_sys::nvinfer1::ISqueezeLayer`] — C++ [`nvinfer1::ISqueezeLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_squeeze_layer.html).
 pub type SqueezeLayer<'layer> = Layer<'layer, nvinfer1::ISqueezeLayer>;
-/// [`trtx_sys::nvinfer1::ITopKLayer`] — C++ [`nvinfer1::ITopKLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_top_k_layer.html).
+/// [`trtx_sys::nvinfer1::ITopKLayer`] — C++ [`nvinfer1::ITopKLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_top_k_layer.html).
 pub type TopKLayer<'layer> = Layer<'layer, nvinfer1::ITopKLayer>;
-/// [`trtx_sys::nvinfer1::IUnaryLayer`] — C++ [`nvinfer1::IUnaryLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_unary_layer.html).
+/// [`trtx_sys::nvinfer1::IUnaryLayer`] — C++ [`nvinfer1::IUnaryLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_unary_layer.html).
 pub type UnaryLayer<'layer> = Layer<'layer, nvinfer1::IUnaryLayer>;
-/// [`trtx_sys::nvinfer1::IUnsqueezeLayer`] — C++ [`nvinfer1::IUnsqueezeLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_unsqueeze_layer.html).
+/// [`trtx_sys::nvinfer1::IUnsqueezeLayer`] — C++ [`nvinfer1::IUnsqueezeLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_unsqueeze_layer.html).
 pub type UnsqueezeLayer<'layer> = Layer<'layer, nvinfer1::IUnsqueezeLayer>;
-/// [`trtx_sys::nvinfer1::IReverseSequenceLayer`] — C++ [`nvinfer1::IReverseSequenceLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_reverse_sequence_layer.html).
+/// [`trtx_sys::nvinfer1::IReverseSequenceLayer`] — C++ [`nvinfer1::IReverseSequenceLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_reverse_sequence_layer.html).
 pub type ReverseSequenceLayer<'layer> = Layer<'layer, nvinfer1::IReverseSequenceLayer>;
-/// [`trtx_sys::nvinfer1::IKVCacheUpdateLayer`] — C++ [`nvinfer1::IKVCacheUpdateLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_k_v_cache_update_layer.html).
+/// [`trtx_sys::nvinfer1::IKVCacheUpdateLayer`] — C++ [`nvinfer1::IKVCacheUpdateLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_k_v_cache_update_layer.html).
 pub type KVCacheUpdateLayer<'layer> = Layer<'layer, nvinfer1::IKVCacheUpdateLayer>;
-/// [`trtx_sys::nvinfer1::ILRNLayer`] — C++ [`nvinfer1::ILRNLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_l_r_n_layer.html).
+/// [`trtx_sys::nvinfer1::ILRNLayer`] — C++ [`nvinfer1::ILRNLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_l_r_n_layer.html).
 pub type LrnLayer<'layer> = Layer<'layer, nvinfer1::ILRNLayer>;
-/// [`trtx_sys::nvinfer1::IOneHotLayer`] — C++ [`nvinfer1::IOneHotLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_one_hot_layer.html).
+/// [`trtx_sys::nvinfer1::IOneHotLayer`] — C++ [`nvinfer1::IOneHotLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_one_hot_layer.html).
 pub type OneHotLayer<'layer> = Layer<'layer, nvinfer1::IOneHotLayer>;
 #[cfg(feature = "v_1_4")]
-/// [`trtx_sys::nvinfer1::IMoELayer`] — C++ [`nvinfer1::IMoELayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_mo_e_layer.html).
+/// [`trtx_sys::nvinfer1::IMoELayer`] — C++ [`nvinfer1::IMoELayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_mo_e_layer.html).
 #[cfg(feature = "v_1_4")]
 pub type MoELayer<'layer> = Layer<'layer, nvinfer1::IMoELayer>;
 #[cfg(feature = "v_1_4")]
-/// [`trtx_sys::nvinfer1::IDistCollectiveLayer`] — C++ [`nvinfer1::IDistCollectiveLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_dist_collective_layer.html).
+/// [`trtx_sys::nvinfer1::IDistCollectiveLayer`] — C++ [`nvinfer1::IDistCollectiveLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_dist_collective_layer.html).
 #[cfg(feature = "v_1_4")]
 pub type DistCollectiveLayer<'layer> = Layer<'layer, nvinfer1::IDistCollectiveLayer>;
 
 // Loop and conditional boundary layers (created via Loop / IfConditional / add_attention)
-/// [`trtx_sys::nvinfer1::IAttentionInputLayer`] — C++ [`nvinfer1::IAttentionInputLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_attention_input_layer.html).
+/// [`trtx_sys::nvinfer1::IAttentionInputLayer`] — C++ [`nvinfer1::IAttentionInputLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_attention_input_layer.html).
 pub type AttentionInputLayer<'layer> = Layer<'layer, nvinfer1::IAttentionInputLayer>;
-/// [`trtx_sys::nvinfer1::IAttentionOutputLayer`] — C++ [`nvinfer1::IAttentionOutputLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_attention_output_layer.html).
+/// [`trtx_sys::nvinfer1::IAttentionOutputLayer`] — C++ [`nvinfer1::IAttentionOutputLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_attention_output_layer.html).
 pub type AttentionOutputLayer<'layer> = Layer<'layer, nvinfer1::IAttentionOutputLayer>;
-/// [`trtx_sys::nvinfer1::IAttentionBoundaryLayer`] — C++ [`nvinfer1::IAttentionBoundaryLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_attention_boundary_layer.html).
+/// [`trtx_sys::nvinfer1::IAttentionBoundaryLayer`] — C++ [`nvinfer1::IAttentionBoundaryLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_attention_boundary_layer.html).
 pub type AttentionBoundaryLayer<'layer> = Layer<'layer, nvinfer1::IAttentionBoundaryLayer>;
-/// [`trtx_sys::nvinfer1::ILoopBoundaryLayer`] — C++ [`nvinfer1::ILoopBoundaryLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_loop_boundary_layer.html).
+/// [`trtx_sys::nvinfer1::ILoopBoundaryLayer`] — C++ [`nvinfer1::ILoopBoundaryLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_loop_boundary_layer.html).
 pub type LoopBoundaryLayer<'layer> = Layer<'layer, nvinfer1::ILoopBoundaryLayer>;
-/// [`trtx_sys::nvinfer1::IRecurrenceLayer`] — C++ [`nvinfer1::IRecurrenceLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_recurrence_layer.html).
+/// [`trtx_sys::nvinfer1::IRecurrenceLayer`] — C++ [`nvinfer1::IRecurrenceLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_recurrence_layer.html).
 pub type RecurrenceLayer<'layer> = Layer<'layer, nvinfer1::IRecurrenceLayer>;
-/// [`trtx_sys::nvinfer1::ILoopOutputLayer`] — C++ [`nvinfer1::ILoopOutputLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_loop_output_layer.html).
+/// [`trtx_sys::nvinfer1::ILoopOutputLayer`] — C++ [`nvinfer1::ILoopOutputLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_loop_output_layer.html).
 pub type LoopOutputLayer<'layer> = Layer<'layer, nvinfer1::ILoopOutputLayer>;
-/// [`trtx_sys::nvinfer1::ITripLimitLayer`] — C++ [`nvinfer1::ITripLimitLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_trip_limit_layer.html).
+/// [`trtx_sys::nvinfer1::ITripLimitLayer`] — C++ [`nvinfer1::ITripLimitLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_trip_limit_layer.html).
 pub type TripLimitLayer<'layer> = Layer<'layer, nvinfer1::ITripLimitLayer>;
-/// [`trtx_sys::nvinfer1::IIteratorLayer`] — C++ [`nvinfer1::IIteratorLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_iterator_layer.html).
+/// [`trtx_sys::nvinfer1::IIteratorLayer`] — C++ [`nvinfer1::IIteratorLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_iterator_layer.html).
 pub type IteratorLayer<'layer> = Layer<'layer, nvinfer1::IIteratorLayer>;
-/// [`trtx_sys::nvinfer1::IConditionLayer`] — C++ [`nvinfer1::IConditionLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_condition_layer.html).
+/// [`trtx_sys::nvinfer1::IConditionLayer`] — C++ [`nvinfer1::IConditionLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_condition_layer.html).
 pub type ConditionLayer<'layer> = Layer<'layer, nvinfer1::IConditionLayer>;
-/// [`trtx_sys::nvinfer1::IIfConditionalOutputLayer`] — C++ [`nvinfer1::IIfConditionalOutputLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_if_conditional_output_layer.html).
+/// [`trtx_sys::nvinfer1::IIfConditionalOutputLayer`] — C++ [`nvinfer1::IIfConditionalOutputLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_if_conditional_output_layer.html).
 pub type IfConditionalOutputLayer<'layer> = Layer<'layer, nvinfer1::IIfConditionalOutputLayer>;
-/// [`trtx_sys::nvinfer1::IIfConditionalInputLayer`] — C++ [`nvinfer1::IIfConditionalInputLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_if_conditional_input_layer.html).
+/// [`trtx_sys::nvinfer1::IIfConditionalInputLayer`] — C++ [`nvinfer1::IIfConditionalInputLayer`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_if_conditional_input_layer.html).
 pub type IfConditionalInputLayer<'layer> = Layer<'layer, nvinfer1::IIfConditionalInputLayer>;
 
 pub type DynLayer<'layer> = Layer<'layer, nvinfer1::ILayer>;
@@ -1313,7 +1313,7 @@ impl MoELayer<'_> {
 /// `IDistCollectiveLayer` adds no methods beyond [`ILayer`](trtx_sys::nvinfer1::ILayer); use [`Layer`] helpers.
 impl DistCollectiveLayer<'_> {}
 
-/// [`trtx_sys::nvinfer1::INetworkDefinition`] — C++ [`nvinfer1::INetworkDefinition`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_network_definition.html).
+/// [`trtx_sys::nvinfer1::INetworkDefinition`] — C++ [`nvinfer1::INetworkDefinition`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_network_definition.html).
 pub struct NetworkDefinition<'builder> {
     //pub(crate) inner: Mutex<Pin<&'builder mut INetworkDefinition>>,
     pub(crate) inner: UniquePtr<INetworkDefinition>,
@@ -1384,7 +1384,7 @@ impl<'network> NetworkDefinition<'network> {
     }
 
     /// See [`trtx_sys::nvinfer1::INetworkDefinition::markDebug`].
-    /// Mark a tensor for debugging; at runtime use [`crate::ExecutionContext`] ([`trtx_sys::nvinfer1::IExecutionContext`]) — C++ [`setDebugListener`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_execution_context.html).
+    /// Mark a tensor for debugging; at runtime use [`crate::ExecutionContext`] ([`trtx_sys::nvinfer1::IExecutionContext`]) — C++ [`setDebugListener`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_execution_context.html).
     pub fn mark_tensor_debug(&mut self, tensor: &'_ Tensor) -> Result<()> {
         check_network!(self, tensor);
         let success = self.inner.pin_mut().markDebug(tensor.pin_mut());
@@ -1447,7 +1447,7 @@ impl<'network> NetworkDefinition<'network> {
     }
 
     /// See [`trtx_sys::nvinfer1::INetworkDefinition::isDebugTensor`].
-    /// See [`trtx_sys::nvinfer1::IExecutionContext`] debug APIs (C++ [docs](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_execution_context.html)).
+    /// See [`trtx_sys::nvinfer1::IExecutionContext`] debug APIs (C++ [docs](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_execution_context.html)).
     pub fn is_debug_tensor(&self, tensor: &'_ Tensor) -> bool {
         check_network!(self, tensor);
         self.inner.isDebugTensor(tensor.as_ref())

--- a/trtx/src/onnx_parser.rs
+++ b/trtx/src/onnx_parser.rs
@@ -1,6 +1,6 @@
 //! ONNX model parser for TensorRT.
 //!
-//! [`OnnxParser`] wraps [`trtx_sys::nvonnxparser::IParser`] (C++ [`nvonnxparser::IParser`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvonnxparser_1_1_i_parser.html)).
+//! [`OnnxParser`] wraps [`trtx_sys::nvonnxparser::IParser`] (C++ [`nvonnxparser::IParser`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvonnxparser_1_1_i_parser.html)).
 
 use std::path::PathBuf;
 
@@ -12,7 +12,7 @@ use crate::error::{Error, Result};
 use crate::logger::Logger;
 use crate::network::NetworkDefinition;
 
-/// [`trtx_sys::nvonnxparser::IParser`] — C++ [`nvonnxparser::IParser`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvonnxparser_1_1_i_parser.html).
+/// [`trtx_sys::nvonnxparser::IParser`] — C++ [`nvonnxparser::IParser`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvonnxparser_1_1_i_parser.html).
 pub struct OnnxParser<'network> {
     inner: UniquePtr<nvonnxparser::IParser>,
     network: NetworkDefinition<'network>,

--- a/trtx/src/optimization_profile.rs
+++ b/trtx/src/optimization_profile.rs
@@ -1,13 +1,13 @@
 //! Optimization profile for dynamic input shapes (min / opt / max dimensions).
 //!
-//! [`OptimizationProfile`] wraps [`trtx_sys::nvinfer1::IOptimizationProfile`] (C++ [`nvinfer1::IOptimizationProfile`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_optimization_profile.html)).
+//! [`OptimizationProfile`] wraps [`trtx_sys::nvinfer1::IOptimizationProfile`] (C++ [`nvinfer1::IOptimizationProfile`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_optimization_profile.html)).
 
 use std::{ffi::CString, marker::PhantomData, pin::Pin};
 
 use crate::{error::PropertySetAttempt, Error, Result};
 use trtx_sys::{nvinfer1, Dims64, OptProfileSelector};
 
-/// [nvinfer1::IOptimizationProfile] — C++ [`nvinfer1::IOptimizationProfile`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_optimization_profile.html).
+/// [nvinfer1::IOptimizationProfile] — C++ [`nvinfer1::IOptimizationProfile`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_optimization_profile.html).
 pub struct OptimizationProfile<'builder> {
     pub(crate) inner: Pin<&'builder mut nvinfer1::IOptimizationProfile>,
     _builder: PhantomData<&'builder nvinfer1::IBuilder>,

--- a/trtx/src/refitter.rs
+++ b/trtx/src/refitter.rs
@@ -1,7 +1,7 @@
 //! Engine refitter (update weights in a deserialized engine).
 //!
-//! [`Refitter`] wraps [`trtx_sys::nvinfer1::IRefitter`] (C++ [`nvinfer1::IRefitter`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_refitter.html)).
-//! [`Weights`] mirrors [`trtx_sys::nvinfer1::Weights`] (C++ [`nvinfer1::Weights`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_weights.html)).
+//! [`Refitter`] wraps [`trtx_sys::nvinfer1::IRefitter`] (C++ [`nvinfer1::IRefitter`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_refitter.html)).
+//! [`Weights`] mirrors [`trtx_sys::nvinfer1::Weights`] (C++ [`nvinfer1::Weights`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_weights.html)).
 
 use std::ffi::{CStr, CString};
 use std::marker::PhantomData;
@@ -15,7 +15,7 @@ use crate::{
 use autocxx::cxx::UniquePtr;
 use trtx_sys::{nvinfer1, DataType};
 
-/// View compatible with [`trtx_sys::nvinfer1::Weights`]; C++ [`nvinfer1::Weights`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_weights.html).
+/// View compatible with [`trtx_sys::nvinfer1::Weights`]; C++ [`nvinfer1::Weights`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_weights.html).
 #[derive(Debug)]
 pub struct Weights<'data, T> {
     data: &'data [T],
@@ -32,7 +32,7 @@ impl<T> Weights<'_, T> {
     }
 }
 
-/// [`trtx_sys::nvinfer1::IRefitter`] — C++ [`nvinfer1::IRefitter`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_refitter.html).
+/// [`trtx_sys::nvinfer1::IRefitter`] — C++ [`nvinfer1::IRefitter`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_refitter.html).
 pub struct Refitter<'logger, 'engine> {
     inner: UniquePtr<nvinfer1::IRefitter>,
     error_recorder: Option<Pin<Box<ErrorRecorder>>>,

--- a/trtx/src/runtime.rs
+++ b/trtx/src/runtime.rs
@@ -1,7 +1,7 @@
 //! Runtime for deserializing and managing TensorRT engines.
 //!
-//! [`Runtime`] wraps [`trtx_sys::nvinfer1::IRuntime`] (C++ [`nvinfer1::IRuntime`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_runtime.html)).
-//! [`ExecutionContext`] wraps [`trtx_sys::nvinfer1::IExecutionContext`] (C++ [`nvinfer1::IExecutionContext`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_execution_context.html)).
+//! [`Runtime`] wraps [`trtx_sys::nvinfer1::IRuntime`] (C++ [`nvinfer1::IRuntime`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_runtime.html)).
+//! [`ExecutionContext`] wraps [`trtx_sys::nvinfer1::IExecutionContext`] (C++ [`nvinfer1::IExecutionContext`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_execution_context.html)).
 
 use std::marker::PhantomData;
 
@@ -18,7 +18,7 @@ use crate::logger::Logger;
 pub use crate::runtime_cache::RuntimeCache;
 pub use crate::runtime_config::RuntimeConfig;
 
-/// [`trtx_sys::nvinfer1::IRuntime`] — C++ [`nvinfer1::IRuntime`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_runtime.html).
+/// [`trtx_sys::nvinfer1::IRuntime`] — C++ [`nvinfer1::IRuntime`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_runtime.html).
 pub struct Runtime<'logger> {
     inner: UniquePtr<nvinfer1::IRuntime>,
     _logger: PhantomData<&'logger Logger>,

--- a/trtx/src/runtime_cache.rs
+++ b/trtx/src/runtime_cache.rs
@@ -1,6 +1,6 @@
 //! Runtime cache for TensorRT JIT compilation (serialize / deserialize).
 //!
-//! [`RuntimeCache`] wraps [`trtx_sys::nvinfer1::IRuntimeCache`] (C++ [`nvinfer1::IRuntimeCache`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_runtime_cache.html).
+//! [`RuntimeCache`] wraps [`trtx_sys::nvinfer1::IRuntimeCache`] (C++ [`nvinfer1::IRuntimeCache`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_runtime_cache.html).
 
 use crate::error::{PropertySetAttempt, Result};
 use crate::host_memory::HostMemory;
@@ -8,7 +8,7 @@ use crate::Error;
 use cxx::UniquePtr;
 use trtx_sys::nvinfer1::{self, IRuntimeCache};
 
-/// [`trtx_sys::nvinfer1::IRuntimeCache`] — C++ [`nvinfer1::IRuntimeCache`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_runtime_cache.html).
+/// [`trtx_sys::nvinfer1::IRuntimeCache`] — C++ [`nvinfer1::IRuntimeCache`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_runtime_cache.html).
 pub struct RuntimeCache {
     pub(crate) inner: UniquePtr<IRuntimeCache>,
 }

--- a/trtx/src/runtime_config.rs
+++ b/trtx/src/runtime_config.rs
@@ -1,6 +1,6 @@
 //! Runtime configuration for execution context creation.
 //!
-//! [`RuntimeConfig`] wraps [`trtx_sys::nvinfer1::IRuntimeConfig`] (C++ [`nvinfer1::IRuntimeConfig`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_runtime_config.html)).
+//! [`RuntimeConfig`] wraps [`trtx_sys::nvinfer1::IRuntimeConfig`] (C++ [`nvinfer1::IRuntimeConfig`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_runtime_config.html)).
 
 use std::marker::PhantomData;
 #[cfg(not(feature = "enterprise"))]
@@ -19,7 +19,7 @@ use trtx_sys::ExecutionContextAllocationStrategy;
 #[cfg(not(feature = "enterprise"))]
 use trtx_sys::{CudaGraphStrategy, DynamicShapesKernelSpecializationStrategy};
 
-/// [`trtx_sys::nvinfer1::IRuntimeConfig`] — C++ [`nvinfer1::IRuntimeConfig`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_runtime_config.html).
+/// [`trtx_sys::nvinfer1::IRuntimeConfig`] — C++ [`nvinfer1::IRuntimeConfig`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_runtime_config.html).
 pub struct RuntimeConfig<'engine> {
     pub(crate) inner: UniquePtr<IRuntimeConfig>,
     _engine: PhantomData<&'engine nvinfer1::ICudaEngine>,

--- a/trtx/src/tensor.rs
+++ b/trtx/src/tensor.rs
@@ -3,7 +3,7 @@ use std::pin::Pin;
 use crate::{network::check_network, Error, NetworkDefinition, Result};
 use trtx_sys::{nvinfer1, DataType, Dims64};
 
-/// [`trtx_sys::nvinfer1::ITensor`] — C++ [`nvinfer1::ITensor`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/cpp-api/classnvinfer1_1_1_i_tensor.html).
+/// [`trtx_sys::nvinfer1::ITensor`] — C++ [`nvinfer1::ITensor`](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/_static/c-api/classnvinfer1_1_1_i_tensor.html).
 #[derive(Clone, Copy)]
 pub struct Tensor<'network> {
     pub(crate) inner: *mut nvinfer1::ITensor,


### PR DESCRIPTION
`cpp-api` changed to `c-api` and docs to `ILogger` moved.

Checked using `lychee **/*.rs` link checker.